### PR TITLE
Amianalyze unit tests

### DIFF
--- a/jwst/ami/__init__.py
+++ b/jwst/ami/__init__.py
@@ -1,7 +1,10 @@
 from .ami_analyze_step import AmiAnalyzeStep
+
 # from .ami_average_step import AmiAverageStep
 from .ami_normalize_step import AmiNormalizeStep
 
-__all__ = ['AmiAnalyzeStep', 
-			# 'AmiAverageStep', 
-			'AmiNormalizeStep']
+__all__ = [
+    "AmiAnalyzeStep",
+    # 'AmiAverageStep',
+    "AmiNormalizeStep",
+]

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -143,7 +143,6 @@ def apply_LG_plus(
             src_spec,
             trim=0.01,
             nlambda=nspecbin,
-            plot=False
         )
 
     rotsearch_d = np.append(np.arange(rotsearch_parameters[0], rotsearch_parameters[1], rotsearch_parameters[2]),

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -13,11 +13,13 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def apply_LG_plus(input_model, throughput_model,
+def apply_LG_plus(
+                input_model,
+                throughput_model,
                 nrm_model,
                 oversample, rotation,
-                psf_offset, rotsearch_parameters, 
-                src, bandpass, usebp, firstfew, 
+                psf_offset, rotsearch_parameters,
+                src, bandpass, usebp, firstfew,
                 chooseholes, affine2d, run_bpfix
                 ):
     """
@@ -136,12 +138,13 @@ def apply_LG_plus(input_model, throughput_model,
         log.info(f'Getting source spectrum for spectral type {src}.')
         src_spec = utils.get_src_spec(src) # always going to be A0V currently
         nspecbin = 19 # how many wavelngth bins used across bandpass -- affects runtime
-        bandpass = utils.combine_src_filt(filt_spec, 
-                                      src_spec, 
-                                      trim=0.01, 
-                                      nlambda=nspecbin,
-                                      plot=False) 
-            
+        bandpass = utils.combine_src_filt(
+            filt_spec,
+            src_spec,
+            trim=0.01,
+            nlambda=nspecbin,
+            plot=False
+        )
 
     rotsearch_d = np.append(np.arange(rotsearch_parameters[0], rotsearch_parameters[1], rotsearch_parameters[2]),
                             rotsearch_parameters[1])
@@ -163,7 +166,7 @@ def apply_LG_plus(input_model, throughput_model,
             box = meddata[y_box - hbox:y_box + hbox + 1, x_box - hbox: x_box + hbox + 1]
             median_fill = np.nanmedian(box)
             if np.isnan(median_fill):
-                median_fill = 0 # not ideal
+                median_fill = 0  # not ideal
             meddata[y_box, x_box] = median_fill
 
         affine2d = find_rotation(meddata, psf_offset, rotsearch_d,
@@ -180,16 +183,15 @@ def apply_LG_plus(input_model, throughput_model,
                                     chooseholes=chooseholes,
                                     run_bpfix=run_bpfix)
 
-    ff_t = nrm_core.FringeFitter(niriss, 
-                                psf_offset_ff=psf_offset_ff,
-                                oversample=oversample)
+    ff_t = nrm_core.FringeFitter(niriss,
+                                 psf_offset_ff=psf_offset_ff,
+                                 oversample=oversample)
 
     oifitsmodel, oifitsmodel_multi, amilgmodel = ff_t.fit_fringes_all(input_copy)
-
 
     # Copy header keywords from input to outputs
     oifitsmodel.update(input_model, only="PRIMARY")
     oifitsmodel_multi.update(input_model, only="PRIMARY")
     amilgmodel.update(input_model, only="PRIMARY")
-    
+
     return oifitsmodel, oifitsmodel_multi, amilgmodel

--- a/jwst/ami/ami_analyze_step.py
+++ b/jwst/ami/ami_analyze_step.py
@@ -7,8 +7,7 @@ __all__ = ["AmiAnalyzeStep"]
 
 
 class AmiAnalyzeStep(Step):
-    """Performs analysis of an AMI mode exposure by applying the LG algorithm.
-    """
+    """Performs analysis of an AMI mode exposure by applying the LG algorithm."""
 
     class_alias = "ami_analyze"
 
@@ -30,8 +29,8 @@ class AmiAnalyzeStep(Step):
 
     def save_model(self, model, *args, **kwargs):
         # Override save_model to change suffix based on list of results
-        if 'idx' in kwargs and kwargs.get('suffix', None) is None:
-            kwargs['suffix'] = ['ami-oi', 'amimulti-oi', 'amilg'][kwargs.pop('idx')]
+        if "idx" in kwargs and kwargs.get("suffix", None) is None:
+            kwargs["suffix"] = ["ami-oi", "amimulti-oi", "amilg"][kwargs.pop("idx")]
         return Step.save_model(self, model, *args, **kwargs)
 
     def process(self, input):
@@ -67,9 +66,9 @@ class AmiAnalyzeStep(Step):
         psf_offset = [float(a) for a in self.psf_offset.split()]
         rotsearch_parameters = [float(a) for a in self.rotation_search.split()]
 
-        self.log.info(f'Oversampling factor = {oversample}')
-        self.log.info(f'Initial rotation guess = {rotate} deg')
-        self.log.info(f'Initial values to use for psf offset = {psf_offset}')
+        self.log.info(f"Oversampling factor = {oversample}")
+        self.log.info(f"Initial rotation guess = {rotate} deg")
+        self.log.info(f"Initial values to use for psf offset = {psf_offset}")
 
         # Make sure oversample is odd
         if oversample % 2 == 0:
@@ -101,12 +100,18 @@ class AmiAnalyzeStep(Step):
                     input_model,
                     throughput_model,
                     nrm_model,
-                    oversample, rotate,
+                    oversample,
+                    rotate,
                     psf_offset,
                     rotsearch_parameters,
-                    src, bandpass, usebp,
-                    firstfew, chooseholes, affine2d,
-                    run_bpfix)
+                    src,
+                    bandpass,
+                    usebp,
+                    firstfew,
+                    chooseholes,
+                    affine2d,
+                    run_bpfix,
+                )
 
         amilgmodel.meta.cal_step.ami_analyze = 'COMPLETE'
         oifitsmodel.meta.cal_step.ami_analyze = 'COMPLETE'

--- a/jwst/ami/ami_normalize_step.py
+++ b/jwst/ami/ami_normalize_step.py
@@ -14,7 +14,6 @@ class AmiNormalizeStep(Step):
 
     class_alias = "ami_normalize"
 
-
     spec = """
     suffix = string(default='aminorm-oi')
     """
@@ -45,7 +44,7 @@ class AmiNormalizeStep(Step):
         # Call the normalization routine
         result = ami_normalize.normalize_LG(target_model, reference_model)
 
-        result.meta.cal_step.ami_normalize = 'COMPLETE'
+        result.meta.cal_step.ami_normalize = "COMPLETE"
 
         # Close the input models
         target_model.close()

--- a/jwst/ami/bp_fix.py
+++ b/jwst/ami/bp_fix.py
@@ -174,7 +174,6 @@ def bad_pixels(data,
     -------
     pxdq: int array
         Bad pixel mask identified by median filtering
-    
     """
 
     mfil_data = median_filter(data, size=median_size)
@@ -210,7 +209,6 @@ def fourier_corr(data,
     -------
     data_out: numpy array
         Corrected science data
-    
     """
 
     # Get the dimensions.
@@ -248,7 +246,7 @@ def fix_bad_pixels(data, pxdq0, filt, pxsc, nrm_model):
     """
     Short Summary
     ------------
-    Apply the Fourier bad pixel correction to pixels 
+    Apply the Fourier bad pixel correction to pixels
     flagged DO_NOT_USE or JUMP_DET.
     Original code implementation by Jens Kammerer.
 
@@ -269,7 +267,7 @@ def fix_bad_pixels(data, pxdq0, filt, pxsc, nrm_model):
     -------
     data: numpy array
         Corrected data
-    pxdq: 
+    pxdq:
         Mask of bad pixels, updated if new ones were found
 
     """
@@ -318,7 +316,6 @@ def fix_bad_pixels(data, pxdq0, filt, pxsc, nrm_model):
     cvis = calcsupport(filt, 2 * sh, pxsc_rad, pupil_mask)
     cvis /= np.max(cvis)
     fmas = cvis < 1e-3  # 1e-3 seems to be a reasonable threshold
-    # fmas_show = fmas.copy()
     fmas = np.fft.fftshift(fmas)[:, :2 * sh // 2 + 1]
 
     # Compute the pupil mask. This mask defines the region where we are
@@ -331,9 +328,6 @@ def fix_bad_pixels(data, pxdq0, filt, pxsc, nrm_model):
         pmas = dist > 9. * filtwl_d[filt] / diam * 180. / np.pi * 1000. * 3600. / pxsc
     else:
         pmas = dist > 12. * filtwl_d[filt] / diam * 180. / np.pi * 1000. * 3600. / pxsc
-    # if (np.sum(pmas) < np.mean(flagged_per_int)):
-    #     log.info('   SKIPPING: subframe too small to estimate noise')
-    #     continue
 
 
     # Go through all frames.
@@ -347,25 +341,11 @@ def fix_bad_pixels(data, pxdq0, filt, pxsc, nrm_model):
         data_orig = deepcopy(data_cut)
         pxdq_cut = deepcopy(pxdq[j,:-1,:-1])
         pxdq_cut = pxdq_cut > 0.5
-        # pxdq_orig = deepcopy(pxdq_cut)
         # Correct the bad pixels. This is an iterative process. After each
         # iteration, we check whether new (residual) bad pixels are
         # identified. If so, we re-compute the corrections. If not, we
         # terminate the iteration.      
         for k in range(10):
-
-            # plt.figure()
-            # plt.imshow(np.log10(data_cut), origin='lower')
-            # plt.imshow(pmas, alpha=0.5, origin='lower')
-            # plt.colorbar()
-            # plt.show()
-
-            # plt.figure()
-            # plt.imshow(np.log10(np.abs(np.fft.rfft2(np.fft.fftshift(data_cut)))), origin='lower')
-            # plt.imshow(fmas, alpha=0.5, origin='lower')
-            # plt.colorbar()
-            # plt.show()
-
             # Correct the bad pixels.
             data_cut = fourier_corr(data_cut,
                                     pxdq_cut,
@@ -408,4 +388,4 @@ def fix_bad_pixels(data, pxdq0, filt, pxsc, nrm_model):
         data[j,:-1,:-1] = fourier_corr(data_orig,pxdq_cut,fmas)
         pxdq[j,:-1,:-1] = pxdq_cut
 
-    return data, pxdq 
+    return data, pxdq

--- a/jwst/ami/find_affine2d_parameters.py
+++ b/jwst/ami/find_affine2d_parameters.py
@@ -118,7 +118,4 @@ def find_rotation(imagedata, psf_offset, rotdegs, mx, my, sx, sy, xo, yo,
     new_affine2d = utils.Affine2d(rotradccw=np.pi * rot_measured_d / 180.0,
                                   name="{0:.4f}".format(rot_measured_d))
 
-    # make logging statements
-    # print('rot_measured_d',rot_measured_d)
-
     return new_affine2d

--- a/jwst/ami/hextransformee.py
+++ b/jwst/ami/hextransformee.py
@@ -38,10 +38,10 @@ def gfunction(xi, eta, **kwargs):
         Fourier transform of one half of a hexagon.
     """
 
-    c = kwargs['c']
-    pixel = kwargs['pixel']
-    d = kwargs['d']
-    lam = kwargs['lam']
+    c = kwargs["c"]
+    pixel = kwargs["pixel"]
+    d = kwargs["d"]
+    lam = kwargs["lam"]
     xi = (d / lam) * pixel * (xi - c[0])
     eta = (d / lam) * pixel * (eta - c[1])
     affine2d = kwargs["affine2d"]
@@ -51,17 +51,22 @@ def gfunction(xi, eta, **kwargs):
 
     xip, etap = affine2d.distortFargs(xi, eta)
 
-    if kwargs['minus'] is True:
+    if kwargs["minus"] is True:
         xip = -1 * xip
 
-    g = np.exp(-i * Pi * (2 * etap / np.sqrt(3) + xip)) * \
-        (
-        (np.sqrt(3) * etap - 3 * xip) *
-        (np.exp(i * Pi * np.sqrt(3) * etap) - np.exp(i * Pi * (4 * etap / np.sqrt(3) + xip))) +
-        (np.sqrt(3) * etap + 3 * xip) *
-        (np.exp(i * Pi * etap / np.sqrt(3)) - np.exp(i * Pi * xip))
-    ) / \
-        (4 * Pi * Pi * (etap * etap * etap - 3 * etap * xip * xip))
+    g = (
+        np.exp(-i * Pi * (2 * etap / np.sqrt(3) + xip))
+        * (
+            (np.sqrt(3) * etap - 3 * xip)
+            * (
+                np.exp(i * Pi * np.sqrt(3) * etap)
+                - np.exp(i * Pi * (4 * etap / np.sqrt(3) + xip))
+            )
+            + (np.sqrt(3) * etap + 3 * xip)
+            * (np.exp(i * Pi * etap / np.sqrt(3)) - np.exp(i * Pi * xip))
+        )
+        / (4 * Pi * Pi * (etap * etap * etap - 3 * etap * xip * xip))
+    )
 
     return g * affine2d.distortphase(xi, eta)
 
@@ -115,11 +120,26 @@ def hextransform(s=None, c=None, d=None, lam=None, pitch=None, affine2d=None):
     if abs(d1) < 0.5 * eps_offset:  # might have the singular central pixel here
         c_adjust[1] = c[1] + eps_offset
 
-    hex_complex = np.fromfunction(gfunction, s, d=d, c=c_adjust, lam=lam,
-                                  pixel=pitch, affine2d=affine2d, minus=False) + \
-        np.fromfunction(gfunction, s, d=d, c=c_adjust, lam=lam,
-                        pixel=pitch, affine2d=affine2d, minus=True)
-    fudge = np.sqrt(4.0) # this gives the analytic central PSF correctly.
-    hex_complex[int(c[0]),int(c[1])] = fudge * (np.sqrt(3) / 4.0)
+    hex_complex = np.fromfunction(
+        gfunction,
+        s,
+        d=d,
+        c=c_adjust,
+        lam=lam,
+        pixel=pitch,
+        affine2d=affine2d,
+        minus=False,
+    ) + np.fromfunction(
+        gfunction,
+        s,
+        d=d,
+        c=c_adjust,
+        lam=lam,
+        pixel=pitch,
+        affine2d=affine2d,
+        minus=True,
+    )
+    fudge = np.sqrt(4.0)  # this gives the analytic central PSF correctly.
+    hex_complex[int(c[0]), int(c[1])] = fudge * (np.sqrt(3) / 4.0)
 
     return hex_complex

--- a/jwst/ami/instrument_data.py
+++ b/jwst/ami/instrument_data.py
@@ -81,9 +81,18 @@ class NIRISS:
         self.src = src
 
         self.lam_c, self.lam_w = utils.get_cw_beta(self.throughput)
-        self.wls = [self.throughput, ]
+        self.wls = [
+            self.throughput,
+        ]
         # Wavelength info for NIRISS bands F277W, F380M, F430M, or F480M
-        self.wavextension = ([self.lam_c,], [self.lam_w,])
+        self.wavextension = (
+            [
+                self.lam_c,
+            ],
+            [
+                self.lam_w,
+            ],
+        )
         self.nwav = 1
 
         # only one NRM on JWST:
@@ -91,7 +100,11 @@ class NIRISS:
         self.instrument = "NIRISS"
         self.arrname = "jwst_g7s6c"
         self.holeshape = "hex"
-        self.mask = NRM_mask_definitions(maskname=self.arrname, chooseholes=self.chooseholes, holeshape=self.holeshape)
+        self.mask = NRM_mask_definitions(
+            maskname=self.arrname,
+            chooseholes=self.chooseholes,
+            holeshape=self.holeshape,
+        )
 
         # save affine deformation of pupil object or create a no-deformation object.
         # We apply this when sampling the PSF, not to the pupil geometry.
@@ -100,9 +113,9 @@ class NIRISS:
         # Separating detector tilt pixel scale effects from pupil distortion effects is
         # yet to be determined... see comments in Affine class definition.
         if affine2d is None:
-            self.affine2d = utils.Affine2d(mx=1.0, my=1.0,
-                               sx=0.0, sy=0.0,
-                               xo=0.0, yo=0.0, name="Ideal")
+            self.affine2d = utils.Affine2d(
+                mx=1.0, my=1.0, sx=0.0, sy=0.0, xo=0.0, yo=0.0, name="Ideal"
+            )
         else:
             self.affine2d = affine2d
 
@@ -112,9 +125,13 @@ class NIRISS:
         # for the threshold application.
         # Data reduction gurus: tweak the threshold value with experience...
         # Gurus: tweak cvsupport with use...
-        self.cvsupport_threshold = {"F277W": 0.02, "F380M": 0.02, "F430M": 0.02, "F480M": 0.02}
+        self.cvsupport_threshold = {
+            "F277W": 0.02,
+            "F380M": 0.02,
+            "F430M": 0.02,
+            "F480M": 0.02,
+        }
         self.threshold = self.cvsupport_threshold[filt]
-
 
     def set_pscale(self, pscalex_deg=None, pscaley_deg=None):
         """
@@ -172,7 +189,7 @@ class NIRISS:
         # At some point we want to use different X and Y pixel scales
         pscale_deg = np.mean([pscaledegx, pscaledegy])
         self.pscale_rad = np.deg2rad(pscale_deg)
-        self.pscale_mas = pscale_deg * (60*60*1000)
+        self.pscale_mas = pscale_deg * (60 * 60 * 1000)
         self.pav3 = input_model.meta.pointing.pa_v3
         self.vparity = input_model.meta.wcsinfo.vparity
         self.v3iyang = input_model.meta.wcsinfo.v3yangle
@@ -181,11 +198,11 @@ class NIRISS:
         self.crpix2 = input_model.meta.wcsinfo.crpix2
         self.pupil = input_model.meta.instrument.pupil
         self.proposer_name = input_model.meta.target.proposer_name
-        if input_model.meta.target.catalog_name == 'UNKNOWN':
+        if input_model.meta.target.catalog_name == "UNKNOWN":
             objname = input_model.meta.target.proposer_name
         else:
             objname = input_model.meta.target.catalog_name
-        self.objname = objname.replace('-', ' ')
+        self.objname = objname.replace("-", " ")
         self.pi_name = input_model.meta.program.pi_name
         self.ra = input_model.meta.target.ra
         self.dec = input_model.meta.target.dec
@@ -196,8 +213,8 @@ class NIRISS:
         self.spectyp = self.src
 
 
-        datestr = input_model.meta.visit.start_time.replace(' ','T')
-        self.date = datestr # is this the right start time?
+        datestr = input_model.meta.visit.start_time.replace(" ", "T")
+        self.date = datestr  # is this the right start time?
         self.year = datestr[:4]
         self.month = datestr[5:7]
         self.day = datestr[8:10]
@@ -210,85 +227,99 @@ class NIRISS:
             self.itime = effinttm
             if self.firstfew is not None:
                 if scidata.shape[0] > self.firstfew:
-                    log.info(f'Analyzing only the first {self.firstfew:d} integrations')
-                    scidata = scidata[:self.firstfew, :, :]
-                    bpdata = bpdata[:self.firstfew, :, :]
+                    log.info(f"Analyzing only the first {self.firstfew:d} integrations")
+                    scidata = scidata[: self.firstfew, :, :]
+                    bpdata = bpdata[: self.firstfew, :, :]
             self.nwav = scidata.shape[0]
-            [self.wls.append(self.wls[0]) for f in range(self.nwav-1)]
+            [self.wls.append(self.wls[0]) for f in range(self.nwav - 1)]
         # Rotate mask hole centers by pav3 + v3i_yang to be in equatorial coordinates
         ctrs_sky = self.mast2sky()
         oifctrs = np.zeros(self.mask.ctrs.shape)
-        oifctrs[:,0] = ctrs_sky[:,1].copy() * -1
-        oifctrs[:,1] = ctrs_sky[:,0].copy() * -1
+        oifctrs[:, 0] = ctrs_sky[:, 1].copy() * -1
+        oifctrs[:, 1] = ctrs_sky[:, 0].copy() * -1
         self.ctrs_eqt = oifctrs
         self.ctrs_inst = self.mask.ctrs
         self.hdia = self.mask.hdia
         self.nslices = self.nwav
 
         # Trim refpix from all slices
-        scidata = scidata[:,4:, :]
-        bpdata = bpdata[:,4:, :]
+        scidata = scidata[:, 4:, :]
+        bpdata = bpdata[:, 4:, :]
 
         # find peak in median of refpix-trimmed scidata
         med_im = np.median(scidata, axis=0)
 
         # Use median image to find big CR hits not already caught by pipeline
-        std_im = np.std(scidata,axis=0)
+        std_im = np.std(scidata, axis=0)
         mediandiff = np.empty_like(scidata)
-        mediandiff[:,:,:] = scidata - med_im
+        mediandiff[:, :, :] = scidata - med_im
         nsigma = 10
-        outliers = np.where(mediandiff > nsigma*std_im)
-        outliers2 = np.argwhere(mediandiff > nsigma*std_im)
+        outliers = np.where(mediandiff > nsigma * std_im)
+        outliers2 = np.argwhere(mediandiff > nsigma * std_im)
 
         dqvalues = bpdata[outliers]
-        log.info(f'{len(dqvalues)} additional pixels >10-sig from median of stack found')
+        log.info(
+            f"{len(dqvalues)} additional pixels >10-sig from median of stack found"
+        )
         # decompose DQ values to check if they are already flagged DNU
         count = 0
-        for loc, dq_value in zip(outliers2,dqvalues):
+        for loc, dq_value in zip(outliers2, dqvalues):
             bitarr = np.binary_repr(dq_value)
             bad_types = []
             for i, elem in enumerate(bitarr[::-1]):
                 if elem == str(1):
-                    badval = 2** i
-                    key = next(key for key, value in dqflags.pixel.items() if value == badval)
+                    badval = 2**i
+                    key = next(
+                        key for key, value in dqflags.pixel.items() if value == badval
+                    )
                     bad_types.append(key)
-            if 'DO_NOT_USE' not in bad_types:
-                bpdata[loc[0],loc[1],loc[2]] += 1
-                count+=1
-        log.info(f'{count} DO_NOT_USE flags added to DQ array for found outlier pixels')
+            if "DO_NOT_USE" not in bad_types:
+                bpdata[loc[0], loc[1], loc[2]] += 1
+                count += 1
+        log.info(f"{count} DO_NOT_USE flags added to DQ array for found outlier pixels")
 
         # Roughly center scidata, bpdata around peak pixel position
         peakx, peaky, r = utils.min_distance_to_edge(med_im)
-        scidata_ctrd = scidata[:,int(peakx-r):int(peakx+r+1), int(peaky-r):int(peaky+r+1)]
-        bpdata_ctrd = bpdata[:,int(peakx-r):int(peakx+r+1), int(peaky-r):int(peaky+r+1)]
+        scidata_ctrd = scidata[
+            :, int(peakx - r):int(peakx + r + 1), int(peaky - r):int(peaky + r + 1)
+        ]
+        bpdata_ctrd = bpdata[
+            :, int(peakx - r):int(peakx + r + 1), int(peaky - r):int(peaky + r + 1)
+        ]
 
-        log.info("Cropping all integrations to %ix%i pixels around peak (%i,%i)" %
-                (2*r+1,2*r+1,peakx+4,peaky))# +4 because of trimmed refpx
+        log.info(
+            "Cropping all integrations to %ix%i pixels around peak (%i,%i)"
+            % (2 * r + 1, 2 * r + 1, peakx + 4, peaky)
+        )  # +4 because of trimmed refpx
         # apply bp fix here
         if self.run_bpfix:
             log.info('Applying Fourier bad pixel correction to cropped data, updating DQ array')
-            scidata_ctrd, bpdata_ctrd = bp_fix.fix_bad_pixels(scidata_ctrd,
-                                                            bpdata_ctrd,
-                                                            input_model.meta.instrument.filter,
-                                                            self.pscale_mas,
-                                                            self.nrm_model)
+            scidata_ctrd, bpdata_ctrd = bp_fix.fix_bad_pixels(
+                scidata_ctrd,
+                bpdata_ctrd,
+                input_model.meta.instrument.filter,
+                self.pscale_mas,
+                self.nrm_model,
+            )
         else:
-            log.info('Not running Fourier bad pixel fix')
+            log.info("Not running Fourier bad pixel fix")
 
-        self.rootfn = input_model.meta.filename.replace('.fits','')
+        self.rootfn = input_model.meta.filename.replace(".fits", "")
 
         # all info needed to write out oifits should be stored in NIRISS object attributes
 
         # Make a bad pixel mask, either from real DQ data or zeros if usebp=False
         if self.usebp:
-            log.info('usebp flag set to TRUE: bad pixels will be excluded from model fit')
+            log.info(
+                "usebp flag set to TRUE: bad pixels will be excluded from model fit"
+            )
             DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
             JUMP_DET = dqflags.pixel["JUMP_DET"]
             dq_dnu = bpdata_ctrd & DO_NOT_USE == DO_NOT_USE
             dq_jump = bpdata_ctrd & JUMP_DET == JUMP_DET
             dqmask_ctrd = dq_dnu | dq_jump
         else:
-            log.info('usebp flag set to FALSE: all pixels will be used in model fit')
+            log.info("usebp flag set to FALSE: all pixels will be used in model fit")
             dqmask_ctrd = np.zeros_like(scidata_ctrd)
 
         return scidata_ctrd, dqmask_ctrd
@@ -327,9 +358,9 @@ class NIRISS:
         # rotate by an extra 90 degrees (RAC 9/21)
         # these coords are just used to orient output in OIFITS files
         # NOT used for the fringe fitting itself
-        mask_ctrs = utils.rotate2dccw(mask_ctrs,np.pi/2.)
-        vpar = self.vparity # Relative sense of rotation between Ideal xy and V2V3
-        rot_ang = self.pav3 - self.v3iyang # subject to change!
+        mask_ctrs = utils.rotate2dccw(mask_ctrs, np.pi / 2.0)
+        vpar = self.vparity  # Relative sense of rotation between Ideal xy and V2V3
+        rot_ang = self.pav3 - self.v3iyang  # subject to change!
 
         if self.pav3 != 0.0:
             # Using rotate2sccw, which rotates **vectors** CCW in a fixed coordinate system,
@@ -337,11 +368,15 @@ class NIRISS:
             if vpar == -1:
                 # rotate clockwise  <rotate coords clockwise>
                 ctrs_rot = utils.rotate2dccw(mask_ctrs, np.deg2rad(-rot_ang))
-                log.info(f'Rotating mask hole centers clockwise by {rot_ang:.3f} degrees')
+                log.info(
+                    f"Rotating mask hole centers clockwise by {rot_ang:.3f} degrees"
+                )
             else:
                 # counterclockwise  <rotate coords counterclockwise>
                 ctrs_rot = utils.rotate2dccw(mask_ctrs, np.deg2rad(rot_ang))
-                log.info(f'Rotating mask hole centers counterclockwise by {rot_ang:.3f} degrees')
+                log.info(
+                    f"Rotating mask hole centers counterclockwise by {rot_ang:.3f} degrees"
+                )
         else:
             ctrs_rot = mask_ctrs
         return ctrs_rot

--- a/jwst/ami/instrument_data.py
+++ b/jwst/ami/instrument_data.py
@@ -18,7 +18,7 @@ log.setLevel(logging.DEBUG)
 
 
 class NIRISS:
-    def __init__(self, 
+    def __init__(self,
                  filt,
                  nrm_model,
                  src="A0V",
@@ -55,7 +55,7 @@ class NIRISS:
             None, synphot object or [(wt,wlen),(wt,wlen),...].  Monochromatic would be e.g. [(1.0, 4.3e-6)]
             Explicit bandpass arg will replace *all* niriss filter-specific variables with
             the given bandpass, so you can simulate 21cm psfs through something called "F430M"!
-        
+
         usebp : boolean
             If True, exclude pixels marked DO_NOT_USE from fringe fitting
 
@@ -204,8 +204,8 @@ class NIRISS:
         effinttm = input_model.meta.exposure.effective_exposure_time
         nints = input_model.meta.exposure.nints
         # if 2d input, model has already been expanded to 3d, so check 0th dimension
-        if input_model.data.shape[0] == 1: 
-            self.itime = effinttm * nints 
+        if input_model.data.shape[0] == 1:
+            self.itime = effinttm * nints
         else:
             self.itime = effinttm
             if self.firstfew is not None:
@@ -236,7 +236,7 @@ class NIRISS:
         std_im = np.std(scidata,axis=0)
         mediandiff = np.empty_like(scidata)
         mediandiff[:,:,:] = scidata - med_im
-        nsigma = 10 
+        nsigma = 10
         outliers = np.where(mediandiff > nsigma*std_im)
         outliers2 = np.argwhere(mediandiff > nsigma*std_im)
 
@@ -262,7 +262,7 @@ class NIRISS:
         scidata_ctrd = scidata[:,int(peakx-r):int(peakx+r+1), int(peaky-r):int(peaky+r+1)]
         bpdata_ctrd = bpdata[:,int(peakx-r):int(peakx+r+1), int(peaky-r):int(peaky+r+1)]
 
-        log.info("Cropping all integrations to %ix%i pixels around peak (%i,%i)" % 
+        log.info("Cropping all integrations to %ix%i pixels around peak (%i,%i)" %
                 (2*r+1,2*r+1,peakx+4,peaky))# +4 because of trimmed refpx
         # apply bp fix here
         if self.run_bpfix:
@@ -278,7 +278,7 @@ class NIRISS:
         self.rootfn = input_model.meta.filename.replace('.fits','')
 
         # all info needed to write out oifits should be stored in NIRISS object attributes
-  
+
         # Make a bad pixel mask, either from real DQ data or zeros if usebp=False
         if self.usebp:
             log.info('usebp flag set to TRUE: bad pixels will be excluded from model fit')

--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -509,7 +509,7 @@ def weighted_operations(img, model, dqm=None):
     cond = None
     return x, res, cond, singvals # no condition number yet...
 
-def matrix_operations(img, model, flux = None, verbose=False, linfit=False, dqm=None):
+def matrix_operations(img, model, flux = None, linfit=False, dqm=None):
     """
     Short Summary
     -------------
@@ -547,38 +547,31 @@ def matrix_operations(img, model, flux = None, verbose=False, linfit=False, dqm=
 
     flatimg = img.reshape(np.shape(img)[0] * np.shape(img)[1])
     flatdqm = dqm.reshape(np.shape(img)[0] * np.shape(img)[1])
-    if verbose: 
-        log.info('fringefitting.leastsqnrm.matrix_operations(): ', end='')
-        log.info(f'\n\timg {img.shape:} \n\tdqm {dqm.shape:}', end='')
-        log.info(f'\n\tL x W = {img.shape[0]:d} x {img.shape[1]:d} = {img.shape[0] * img.shape[1]:d}', end='')
-        log.info(f'\n\tflatimg {flatimg.shape:}', end='')
-        log.info(f'\n\tflatdqm {flatdqm.shape:}', end='')
+    log.info('fringefitting.leastsqnrm.matrix_operations(): ', end='')
+    log.info(f'\n\timg {img.shape:} \n\tdqm {dqm.shape:}', end='')
+    log.info(f'\n\tL x W = {img.shape[0]:d} x {img.shape[1]:d} = {img.shape[0] * img.shape[1]:d}', end='')
+    log.info(f'\n\tflatimg {flatimg.shape:}', end='')
+    log.info(f'\n\tflatdqm {flatdqm.shape:}', end='')
 
     # Originally Alex had  nans coding bad pixels in the image.
     # Anand: re-use the nan terminology code but driven by bad pixel frame
     #        nanlist shoud get renamed eg donotuselist
 
-    if verbose:
-        log.info('\n\ttype(dqm)', type(dqm), end='')
+    log.info('\n\ttype(dqm)', type(dqm), end='')
     if dqm is not None:
         nanlist = np.where(flatdqm)  # where DO_NOT_USE up.
     else:
         nanlist = (np.array(()), ) # shouldn't occur w/MAST JWST data
 
-    if verbose:
-        log.info(f'\n\ttype(nanlist) {type(nanlist):}, len={len(nanlist):}', end='')
-        log.info(f'\n\tnumber of nanlist pixels: {len(nanlist[0]):d} items', end='')
-        log.info(f'\n\t{len(nanlist[0]):d} DO_NOT_USE pixels found in data slice',
-          end='')
-    else:
-        log.info(f'\t{len(nanlist[0]):d} DO_NOT_USE pixels found in data slice')
-
+    log.info(f'\n\ttype(nanlist) {type(nanlist):}, len={len(nanlist):}', end='')
+    log.info(f'\n\tnumber of nanlist pixels: {len(nanlist[0]):d} items', end='')
+    log.info(f'\n\t{len(nanlist[0]):d} DO_NOT_USE pixels found in data slice',
+      end='')
 
     flatimg = np.delete(flatimg, nanlist)
 
-    if verbose:
-        log.info(f'\n\tflatimg {flatimg.shape:} after deleting {len(nanlist[0]):d}',
-          end='')
+    log.info(f'\n\tflatimg {flatimg.shape:} after deleting {len(nanlist[0]):d}',
+      end='')
 
 
     if flux is not None:
@@ -588,12 +581,11 @@ def matrix_operations(img, model, flux = None, verbose=False, linfit=False, dqm=
     flatmodel_nan = model.reshape(np.shape(model)[0] * np.shape(model)[1],
                                   np.shape(model)[2])
     flatmodel = np.zeros((len(flatimg), np.shape(model)[2]))
-    if verbose:
-        log.info(f'\n\tflatmodel_nan {flatmodel_nan.shape:}', end='')
-        log.info(f'\n\tflatmodel     {flatmodel.shape:}', end='')
-        log.info(f'\n\tdifference    {flatmodel_nan.shape[0] - flatmodel.shape[0]:}', end='')
-        log.info("flat model dimensions ", np.shape(flatmodel))
-        log.info("flat image dimensions ", np.shape(flatimg))
+    log.info(f'\n\tflatmodel_nan {flatmodel_nan.shape:}', end='')
+    log.info(f'\n\tflatmodel     {flatmodel.shape:}', end='')
+    log.info(f'\n\tdifference    {flatmodel_nan.shape[0] - flatmodel.shape[0]:}', end='')
+    log.info("flat model dimensions ", np.shape(flatmodel))
+    log.info("flat image dimensions ", np.shape(flatimg))
 
     for fringe in range(np.shape(model)[2]):
         flatmodel[:,fringe] = np.delete(flatmodel_nan[:,fringe], nanlist)
@@ -616,14 +608,13 @@ def matrix_operations(img, model, flux = None, verbose=False, linfit=False, dqm=
     res = np.insert(res, naninsert, np.nan)
     res = res.reshape(img.shape[0], img.shape[1])
 
-    if verbose:
-        log.info('model flux', flux)
-        log.info('data flux', flatimg.sum())
-        log.info("flat model dimensions ", np.shape(flatmodel))
-        log.info("model transpose dimensions ", np.shape(flatmodeltransp))
-        log.info("flat image dimensions ", np.shape(flatimg))
-        log.info("transpose * image data dimensions", np.shape(data_vector))
-        log.info("flat img * transpose dimensions", np.shape(inverse))
+    log.info('model flux', flux)
+    log.info('data flux', flatimg.sum())
+    log.info("flat model dimensions ", np.shape(flatmodel))
+    log.info("model transpose dimensions ", np.shape(flatmodeltransp))
+    log.info("flat image dimensions ", np.shape(flatimg))
+    log.info("transpose * image data dimensions", np.shape(data_vector))
+    log.info("flat img * transpose dimensions", np.shape(inverse))
 
     if linfit:
         try:
@@ -658,12 +649,10 @@ def matrix_operations(img, model, flux = None, verbose=False, linfit=False, dqm=
 
         except ImportError:
             linfit_result = None
-            if verbose:
-                log.info("linearfit module not imported, no covariances saved.")
+            log.info("linearfit module not imported, no covariances saved.")
     else:
         linfit_result = None
-        if verbose:
-            log.info("linearfit module not imported, no covariances saved.")
+        log.info("linearfit module not imported, no covariances saved.")
 
     return x, res, cond, linfit_result
 

--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -57,8 +57,9 @@ def rotatevectors(vectors, thetarad):
     c, s = (np.cos(thetarad), np.sin(thetarad))
     ctrs_rotated = []
     for vector in vectors:
-        ctrs_rotated.append([c * vector[0] - s * vector[1],
-                             s * vector[0] + c * vector[1]])
+        ctrs_rotated.append(
+            [c * vector[0] - s * vector[1], s * vector[0] + c * vector[1]]
+        )
 
     rot_vectors = np.array(ctrs_rotated)
 
@@ -82,7 +83,7 @@ def mas2rad(mas):
         angle in radians
     """
 
-    rad = mas * (10**(-3)) / (3600 * 180 / np.pi)
+    rad = mas * (10 ** (-3)) / (3600 * 180 / np.pi)
     return rad
 
 
@@ -102,7 +103,7 @@ def rad2mas(rad):
     mas: float
         input angle in milli arc sec
     """
-    mas = rad * (3600. * 180 / np.pi) * 10.**3
+    mas = rad * (3600.0 * 180 / np.pi) * 10.0**3
 
     return mas
 
@@ -208,9 +209,14 @@ def primarybeam(kx, ky):
     env_int: 2D float array
         envelope intensity for circular holes & monochromatic light
     """
-    R = (primarybeam.d / primarybeam.lam) * primarybeam.pitch *  \
-        np.sqrt((kx - primarybeam.offx) * (kx - primarybeam.offx) +
-                (ky - primarybeam.offy) * (ky - primarybeam.offy))
+    R = (
+        (primarybeam.d / primarybeam.lam)
+        * primarybeam.pitch
+        * np.sqrt(
+            (kx - primarybeam.offx) * (kx - primarybeam.offx)
+            + (ky - primarybeam.offy) * (ky - primarybeam.offy)
+        )
+    )
     pb = replacenan(jv(1, np.pi * R) / (2.0 * R))
 
     pb = pb.transpose()
@@ -235,8 +241,13 @@ def hexpb():
     pb * pb.conj(): 2D float array
         primary beam for hexagonal holes
     """
-    pb = hexee.hex_eeAG(s=hexpb.size, c=(hexpb.offx, hexpb.offy),
-                        d=hexpb.d, lam=hexpb.lam, pitch=hexpb.pitch)
+    pb = hexee.hex_eeAG(
+        s=hexpb.size,
+        c=(hexpb.offx, hexpb.offy),
+        d=hexpb.d,
+        lam=hexpb.lam,
+        pitch=hexpb.pitch,
+    )
 
     return pb * pb.conj()
 
@@ -257,9 +268,16 @@ def ffc(kx, ky):
     cos_array: 2D float array
         cosine terms of analytic model
     """
-    cos_array = 2 * np.cos(2 * np.pi * ffc.pitch *
-                           ((kx - ffc.offx) * (ffc.ri[0] - ffc.rj[0]) +
-                            (ky - ffc.offy) * (ffc.ri[1] - ffc.rj[1])) / ffc.lam)
+    cos_array = 2 * np.cos(
+        2
+        * np.pi
+        * ffc.pitch
+        * (
+            (kx - ffc.offx) * (ffc.ri[0] - ffc.rj[0])
+            + (ky - ffc.offy) * (ffc.ri[1] - ffc.rj[1])
+        )
+        / ffc.lam
+    )
     return cos_array
 
 
@@ -279,15 +297,23 @@ def ffs(kx, ky):
     sin_array: 2D float array
         sine terms of analytic model
     """
-    sin_array = -2 * np.sin(2 * np.pi * ffs.pitch *
-                            ((kx - ffs.offx) * (ffs.ri[0] - ffs.rj[0]) +
-                             (ky - ffs.offy) * (ffs.ri[1] - ffs.rj[1])) / ffs.lam)
+    sin_array = -2 * np.sin(
+        2
+        * np.pi
+        * ffs.pitch
+        * (
+            (kx - ffs.offx) * (ffs.ri[0] - ffs.rj[0])
+            + (ky - ffs.offy) * (ffs.ri[1] - ffs.rj[1])
+        )
+        / ffs.lam
+    )
 
     return sin_array
 
 
-def model_array(ctrs, lam, oversample, pitch, fov, d,
-                centering='PIXELCENTERED', shape='circ'):
+def model_array(
+    ctrs, lam, oversample, pitch, fov, d, centering="PIXELCENTERED", shape="circ"
+):
     """
     Short Summary
     -------------
@@ -331,20 +357,20 @@ def model_array(ctrs, lam, oversample, pitch, fov, d,
     ffmodel: list of 3 2D float arrays
         model array
     """
-    if centering == 'PIXELCORNER':
+    if centering == "PIXELCORNER":
         off = np.array([0.0, 0.0])
-    elif centering == 'PIXELCENTERED':
+    elif centering == "PIXELCENTERED":
         off = np.array([0.5, 0.5])
     else:
         off = centering
 
-    log.debug('------------------')
-    log.debug('Model Parameters:')
-    log.debug('------------------')
-    log.debug('pitch:%s fov:%s oversampling:%s ', pitch, fov, oversample)
-    log.debug('centers:%s', ctrs)
-    log.debug('wavelength:%s  centering:%s off:%s ', lam, centering, off)
-    log.debug('shape:%s d:%s ', shape, d)
+    log.debug("------------------")
+    log.debug("Model Parameters:")
+    log.debug("------------------")
+    log.debug("pitch:%s fov:%s oversampling:%s ", pitch, fov, oversample)
+    log.debug("centers:%s", ctrs)
+    log.debug("wavelength:%s  centering:%s off:%s ", lam, centering, off)
+    log.debug("shape:%s d:%s ", shape, d)
 
     # primary beam parameters:
     primarybeam.shape = shape
@@ -400,13 +426,15 @@ def model_array(ctrs, lam, oversample, pitch, fov, d,
         ffmodel.append(np.transpose(np.fromfunction(ffc, ffc.size)))
         ffmodel.append(np.transpose(np.fromfunction(ffs, ffs.size)))
 
-    if shape == 'circ':  # if unspecified (default), or specified as 'circ'
+    if shape == "circ":  # if unspecified (default), or specified as 'circ'
         return np.fromfunction(primarybeam, ffc.size), ffmodel
-    elif shape == 'hex':
+    elif shape == "hex":
         return hexpb(), ffmodel
     else:
-        log.critical('Must provide a valid hole shape. Current supported shapes \
-        are circ and hex.')
+        log.critical(
+            "Must provide a valid hole shape. Current supported shapes \
+        are circ and hex."
+        )
         return None
 
 
@@ -458,42 +486,43 @@ def weighted_operations(img, model, dqm=None):
     if dqm is not None:
         nanlist = np.where(flatdqm)  # where DO_NOT_USE up.
     else:
-        nanlist = (np.array(()), ) # shouldn't occur w/MAST JWST data
+        nanlist = (np.array(()),)  # shouldn't occur w/MAST JWST data
 
-    # see original linearfit https://github.com/agreenbaum/ImPlaneIA: 
+    # see original linearfit https://github.com/agreenbaum/ImPlaneIA:
     # agreenbaum committed on May 21, 2017 1 parent 3e0fb8b
     # commit bf02eb52c5813cb5d77036174a7caba703f9d366
-    # 
+    #
     flatimg = np.delete(flatimg, nanlist)  # DATA values
 
-    # photon noise variance - proportional to ADU 
+    # photon noise variance - proportional to ADU
     # (for roughly uniform adu2electron factor)
     variance = np.abs(flatimg)
     # this resets the weights of pixels with negative or unity values to zero
     # we ignore data with unity or lower values - weight it not-at-all..
-    weights = np.where(flatimg <= 1.0, 0.0, 1.0/np.sqrt(variance))  # anand 2022 Jan
+    weights = np.where(flatimg <= 1.0, 0.0, 1.0 / np.sqrt(variance))  # anand 2022 Jan
 
-    log.debug(f'{len(nanlist[0]):d} bad pixels skipped in weighted fringefitter')
+    log.debug(f"{len(nanlist[0]):d} bad pixels skipped in weighted fringefitter")
 
     # A - but delete all pixels flagged by dq array
-    flatmodel_nan = model.reshape(np.shape(model)[0] * np.shape(model)[1],
-                                  np.shape(model)[2])
+    flatmodel_nan = model.reshape(
+        np.shape(model)[0] * np.shape(model)[1], np.shape(model)[2]
+    )
     flatmodel = np.zeros((len(flatimg), np.shape(model)[2]))
     for fringe in range(np.shape(model)[2]):
-        flatmodel[:,fringe] = np.delete(flatmodel_nan[:,fringe], nanlist)
-    #log.info(flatmodel.shape)
+        flatmodel[:, fringe] = np.delete(flatmodel_nan[:, fringe], nanlist)
+    # log.info(flatmodel.shape)
 
-    # A.w 
+    # A.w
     # Aw = A * np.sqrt(w[:,np.newaxis]) # w as a column vector
-    Aw = flatmodel * weights[:,np.newaxis]
+    Aw = flatmodel * weights[:, np.newaxis]
     # bw = b * np.sqrt(w)
     bw = flatimg * weights
     # x = np.linalg.lstsq(Aw, bw)[0]
     # resids are pixel value residuals, flattened to 1d vector
     x, rss, rank, singvals = np.linalg.lstsq(Aw, bw)
 
-    #inverse = linalg.inv(Atww)
-    #cond = np.linalg.cond(inverse)
+    # inverse = linalg.inv(Atww)
+    # cond = np.linalg.cond(inverse)
 
     # actual residuals in image:  is this sign convention odd?
     # res = np.dot(flatmodel, x) - flatimg
@@ -507,9 +536,10 @@ def weighted_operations(img, model, dqm=None):
     res = res.reshape(img.shape[0], img.shape[1])
 
     cond = None
-    return x, res, cond, singvals # no condition number yet...
+    return x, res, cond, singvals  # no condition number yet...
 
-def matrix_operations(img, model, flux = None, linfit=False, dqm=None):
+
+def matrix_operations(img, model, flux=None, linfit=False, dqm=None):
     """
     Short Summary
     -------------
@@ -547,48 +577,51 @@ def matrix_operations(img, model, flux = None, linfit=False, dqm=None):
 
     flatimg = img.reshape(np.shape(img)[0] * np.shape(img)[1])
     flatdqm = dqm.reshape(np.shape(img)[0] * np.shape(img)[1])
-    log.info('fringefitting.leastsqnrm.matrix_operations(): ', end='')
-    log.info(f'\n\timg {img.shape:} \n\tdqm {dqm.shape:}', end='')
-    log.info(f'\n\tL x W = {img.shape[0]:d} x {img.shape[1]:d} = {img.shape[0] * img.shape[1]:d}', end='')
-    log.info(f'\n\tflatimg {flatimg.shape:}', end='')
-    log.info(f'\n\tflatdqm {flatdqm.shape:}', end='')
+    log.info("fringefitting.leastsqnrm.matrix_operations(): ", end="")
+    log.info(f"\n\timg {img.shape:} \n\tdqm {dqm.shape:}", end="")
+    log.info(
+        f"\n\tL x W = {img.shape[0]:d} x {img.shape[1]:d} = {img.shape[0] * img.shape[1]:d}",
+        end="",
+    )
+    log.info(f"\n\tflatimg {flatimg.shape:}", end="")
+    log.info(f"\n\tflatdqm {flatdqm.shape:}", end="")
 
     # Originally Alex had  nans coding bad pixels in the image.
     # Anand: re-use the nan terminology code but driven by bad pixel frame
     #        nanlist shoud get renamed eg donotuselist
 
-    log.info('\n\ttype(dqm)', type(dqm), end='')
+    log.info("\n\ttype(dqm)", type(dqm), end="")
     if dqm is not None:
         nanlist = np.where(flatdqm)  # where DO_NOT_USE up.
     else:
-        nanlist = (np.array(()), ) # shouldn't occur w/MAST JWST data
+        nanlist = (np.array(()),)  # shouldn't occur w/MAST JWST data
 
-    log.info(f'\n\ttype(nanlist) {type(nanlist):}, len={len(nanlist):}', end='')
-    log.info(f'\n\tnumber of nanlist pixels: {len(nanlist[0]):d} items', end='')
-    log.info(f'\n\t{len(nanlist[0]):d} DO_NOT_USE pixels found in data slice',
-      end='')
+    log.info(f"\n\ttype(nanlist) {type(nanlist):}, len={len(nanlist):}", end="")
+    log.info(f"\n\tnumber of nanlist pixels: {len(nanlist[0]):d} items", end="")
+    log.info(f"\n\t{len(nanlist[0]):d} DO_NOT_USE pixels found in data slice", end="")
 
     flatimg = np.delete(flatimg, nanlist)
 
-    log.info(f'\n\tflatimg {flatimg.shape:} after deleting {len(nanlist[0]):d}',
-      end='')
-
+    log.info(f"\n\tflatimg {flatimg.shape:} after deleting {len(nanlist[0]):d}", end="")
 
     if flux is not None:
         flatimg = flux * flatimg / flatimg.sum()
 
     # A
-    flatmodel_nan = model.reshape(np.shape(model)[0] * np.shape(model)[1],
-                                  np.shape(model)[2])
+    flatmodel_nan = model.reshape(
+        np.shape(model)[0] * np.shape(model)[1], np.shape(model)[2]
+    )
     flatmodel = np.zeros((len(flatimg), np.shape(model)[2]))
-    log.info(f'\n\tflatmodel_nan {flatmodel_nan.shape:}', end='')
-    log.info(f'\n\tflatmodel     {flatmodel.shape:}', end='')
-    log.info(f'\n\tdifference    {flatmodel_nan.shape[0] - flatmodel.shape[0]:}', end='')
+    log.info(f"\n\tflatmodel_nan {flatmodel_nan.shape:}", end="")
+    log.info(f"\n\tflatmodel     {flatmodel.shape:}", end="")
+    log.info(
+        f"\n\tdifference    {flatmodel_nan.shape[0] - flatmodel.shape[0]:}", end=""
+    )
     log.info("flat model dimensions ", np.shape(flatmodel))
     log.info("flat image dimensions ", np.shape(flatimg))
 
     for fringe in range(np.shape(model)[2]):
-        flatmodel[:,fringe] = np.delete(flatmodel_nan[:,fringe], nanlist)
+        flatmodel[:, fringe] = np.delete(flatmodel_nan[:, fringe], nanlist)
     # At (A transpose)
     flatmodeltransp = flatmodel.transpose()
     # At.A (makes square matrix)
@@ -608,8 +641,8 @@ def matrix_operations(img, model, flux = None, linfit=False, dqm=None):
     res = np.insert(res, naninsert, np.nan)
     res = res.reshape(img.shape[0], img.shape[1])
 
-    log.info('model flux', flux)
-    log.info('data flux', flatimg.sum())
+    log.info("model flux", flux)
+    log.info("data flux", flatimg.sum())
     log.info("flat model dimensions ", np.shape(flatmodel))
     log.info("model transpose dimensions ", np.shape(flatmodeltransp))
     log.info("flat image dimensions ", np.shape(flatimg))
@@ -627,7 +660,7 @@ def matrix_operations(img, model, flux = None, linfit=False, dqm=None):
             noise = np.sqrt(np.abs(flatimg))
 
             # this sets the weights of pixels fulfilling condition to zero
-            weights = np.where(np.abs(flatimg)<=1.0, 0.0, 1.0/(noise**2))
+            weights = np.where(np.abs(flatimg) <= 1.0, 0.0, 1.0 / (noise**2))
 
             # uniform weight
             wy = weights
@@ -636,7 +669,7 @@ def matrix_operations(img, model, flux = None, linfit=False, dqm=None):
             C = np.mat(flatmodeltransp)
 
             # initialize object
-            result = linearfit.LinearFit(M,S,C)
+            result = linearfit.LinearFit(M, S, C)
 
             # do the fit
             result.fit()
@@ -678,13 +711,18 @@ def multiplyenv(env, fringeterms):
     """
     # The envelope has size (fov, fov). This multiplies the envelope by each
     #    of the 43 slices in the fringe model
-    full = np.ones((np.shape(fringeterms)[1], np.shape(fringeterms)[2],
-                    np.shape(fringeterms)[0] + 1))
+    full = np.ones(
+        (
+            np.shape(fringeterms)[1],
+            np.shape(fringeterms)[2],
+            np.shape(fringeterms)[0] + 1,
+        )
+    )
 
     for i, val in enumerate(fringeterms):
         full[:, :, i] = env * fringeterms[i]
 
-    log.debug('Total number of fringe terms: %s', len(fringeterms) - 1)
+    log.debug("Total number of fringe terms: %s", len(fringeterms) - 1)
 
     return full
 
@@ -719,11 +757,13 @@ def tan2visibilities(coeffs):
     delta = np.zeros(int((len(coeffs) - 1) / 2))
     amp = np.zeros(int((len(coeffs) - 1) / 2))
     for q in range(int((len(coeffs) - 1) / 2)):
-        delta[q] = (np.arctan2(coeffs[2 * q + 2], coeffs[2 * q + 1]))
-        amp[q] = np.sqrt(coeffs[2 * q + 2]**2 + coeffs[2 * q + 1]**2)
+        delta[q] = np.arctan2(coeffs[2 * q + 2], coeffs[2 * q + 1])
+        amp[q] = np.sqrt(coeffs[2 * q + 2] ** 2 + coeffs[2 * q + 1] ** 2)
 
-    log.debug(f"tan2visibilities: shape coeffs:{np.shape(coeffs)} "
-              f"shape delta:{np.shape(delta)}")
+    log.debug(
+        f"tan2visibilities: shape coeffs:{np.shape(coeffs)} "
+        f"shape delta:{np.shape(delta)}"
+    )
 
     # returns fringe amplitude & phase
     return amp, delta
@@ -831,9 +871,11 @@ def redundant_cps(deltaps, n=7):
     for kk in range(n - 2):
         for ii in range(n - kk - 2):
             for jj in range(n - kk - ii - 2):
-                cps[nn + jj] = arr[kk, ii + kk + 1] \
-                    + arr[ii + kk + 1, jj + ii + kk + 2] \
+                cps[nn + jj] = (
+                    arr[kk, ii + kk + 1]
+                    + arr[ii + kk + 1, jj + ii + kk + 2]
                     + arr[jj + ii + kk + 2, kk]
+                )
 
             nn += jj + 1
 
@@ -861,22 +903,43 @@ def closurephase(deltap, n=7):
     """
     # p is a triangular matrix set up to calculate closure phases
     if n == 7:
-        p = np.array([deltap[:6], deltap[6:11], deltap[11:15],
-                      deltap[15:18], deltap[18:20], deltap[20:]], dtype=object)
+        p = np.array(
+            [
+                deltap[:6],
+                deltap[6:11],
+                deltap[11:15],
+                deltap[15:18],
+                deltap[18:20],
+                deltap[20:],
+            ],
+            dtype=object,
+        )
     elif n == 10:
-        p = np.array([deltap[:9], deltap[9:17], deltap[17:24],
-                      deltap[24:30], deltap[30:35], deltap[35:39],
-                      deltap[39:42], deltap[42:44], deltap[44:]], dtype=object)
+        p = np.array(
+            [
+                deltap[:9],
+                deltap[9:17],
+                deltap[17:24],
+                deltap[24:30],
+                deltap[30:35],
+                deltap[35:39],
+                deltap[39:42],
+                deltap[42:44],
+                deltap[44:],
+            ],
+            dtype=object,
+        )
     else:
-        log.critical('invalid hole number: %s', n)
+        log.critical("invalid hole number: %s", n)
 
     # calculates closure phases for general N-hole mask (with p-array set
     #     up properly above)
     cps = np.zeros((n - 1) * (n - 2) // 2)
     for j1 in range(n - 2):
         for j2 in range(n - 2 - j1):
-            cps[int(j1 * ((n + (n - 3) - j1) / 2.0)) + j2] = \
+            cps[int(j1 * ((n + (n - 3) - j1) / 2.0)) + j2] = (
                 p[j1][0] + p[j1 + 1][j2] - p[j1][j2 + 1]
+            )
 
     return cps
 
@@ -909,10 +972,14 @@ def closure_amplitudes(amps, n=7):
         for jj in range(n - ii - 3):
             for kk in range(n - jj - ii - 3):
                 for ll in range(n - jj - ii - kk - 3):
-                    cas[nn + ll] = arr[ii, jj + ii + 1] \
-                        * arr[ll + ii + jj + kk + 3, kk + jj + ii + 2] \
-                        / (arr[ii, kk + ii + jj + 2] *
-                           arr[jj + ii + 1, ll + ii + jj + kk + 3])
+                    cas[nn + ll] = (
+                        arr[ii, jj + ii + 1]
+                        * arr[ll + ii + jj + kk + 3, kk + jj + ii + 2]
+                        / (
+                            arr[ii, kk + ii + jj + 2]
+                            * arr[jj + ii + 1, ll + ii + jj + kk + 3]
+                        )
+                    )
                 nn = nn + ll + 1
 
     return cas

--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -416,17 +416,17 @@ def weighted_operations(img, model, dqm=None):
     -------------
     Performs least squares matrix operations to solve A x = b, where A is the
     model, b is the data (image), and x is the coefficient vector we are solving
-    for.  
+    for.
 
     Solution 1:  equal weighting of data (matrix_operations()).
-      x = inv(At.A).(At.b) 
+      x = inv(At.A).(At.b)
 
     Solution 2:  weighting data by Poisson variance (weighted_operations())
-      x = inv(At.W.A).(At.W.b) 
-      where W is a diagonal matrix of weights w_i, 
+      x = inv(At.W.A).(At.W.b)
+      where W is a diagonal matrix of weights w_i,
       weighting each data point i by the inverse of its variance:
          w_i = 1 / sigma_i^2
-      For photon noise, the data, i.e. the image values b_i  have variance 
+      For photon noise, the data, i.e. the image values b_i  have variance
       proportional to b_i with an e.g. ADU to electrons coonversion factor.
       If this factor is the same for all pixels, we do not need to include
       it here (is that really true? Yes I think so because we're not
@@ -468,7 +468,7 @@ def weighted_operations(img, model, dqm=None):
 
     # photon noise variance - proportional to ADU 
     # (for roughly uniform adu2electron factor)
-    variance = np.abs(flatimg)  
+    variance = np.abs(flatimg)
     # this resets the weights of pixels with negative or unity values to zero
     # we ignore data with unity or lower values - weight it not-at-all..
     weights = np.where(flatimg <= 1.0, 0.0, 1.0/np.sqrt(variance))  # anand 2022 Jan
@@ -476,7 +476,7 @@ def weighted_operations(img, model, dqm=None):
     log.debug(f'{len(nanlist[0]):d} bad pixels skipped in weighted fringefitter')
 
     # A - but delete all pixels flagged by dq array
-    flatmodel_nan = model.reshape(np.shape(model)[0] * np.shape(model)[1], 
+    flatmodel_nan = model.reshape(np.shape(model)[0] * np.shape(model)[1],
                                   np.shape(model)[2])
     flatmodel = np.zeros((len(flatimg), np.shape(model)[2]))
     for fringe in range(np.shape(model)[2]):
@@ -498,7 +498,7 @@ def weighted_operations(img, model, dqm=None):
     # actual residuals in image:  is this sign convention odd?
     # res = np.dot(flatmodel, x) - flatimg
     # changed here to data - model
-    res = flatimg - np.dot(flatmodel, x) 
+    res = flatimg - np.dot(flatmodel, x)
 
     # put bad pixels back
     naninsert = nanlist[0] - np.arange(len(nanlist[0]))
@@ -565,14 +565,14 @@ def matrix_operations(img, model, flux = None, verbose=False, linfit=False, dqm=
     else:
         nanlist = (np.array(()), ) # shouldn't occur w/MAST JWST data
 
-    if verbose: 
+    if verbose:
         log.info(f'\n\ttype(nanlist) {type(nanlist):}, len={len(nanlist):}', end='')
-        log.info(f'\n\tnumber of nanlist pixels: {len(nanlist[0]):d} items', end='') 
+        log.info(f'\n\tnumber of nanlist pixels: {len(nanlist[0]):d} items', end='')
         log.info(f'\n\t{len(nanlist[0]):d} DO_NOT_USE pixels found in data slice',
           end='')
     else:
         log.info(f'\t{len(nanlist[0]):d} DO_NOT_USE pixels found in data slice')
-          
+
 
     flatimg = np.delete(flatimg, nanlist)
 
@@ -585,10 +585,10 @@ def matrix_operations(img, model, flux = None, verbose=False, linfit=False, dqm=
         flatimg = flux * flatimg / flatimg.sum()
 
     # A
-    flatmodel_nan = model.reshape(np.shape(model)[0] * np.shape(model)[1], 
+    flatmodel_nan = model.reshape(np.shape(model)[0] * np.shape(model)[1],
                                   np.shape(model)[2])
     flatmodel = np.zeros((len(flatimg), np.shape(model)[2]))
-    if verbose: 
+    if verbose:
         log.info(f'\n\tflatmodel_nan {flatmodel_nan.shape:}', end='')
         log.info(f'\n\tflatmodel     {flatmodel.shape:}', end='')
         log.info(f'\n\tdifference    {flatmodel_nan.shape[0] - flatmodel.shape[0]:}', end='')

--- a/jwst/ami/lg_model.py
+++ b/jwst/ami/lg_model.py
@@ -14,13 +14,6 @@ log.addHandler(logging.NullHandler())
 log.setLevel(logging.DEBUG)
 
 
-# define phi at the center of F430M band:
-# phi_nb = np.array([0.028838669455909766, -0.061516214504502634,
-#                    0.12390958557781348, -0.020389361461019516,
-#                    0.016557347248600723, -0.03960017912525625,
-#                    -0.04779984719154552])  # phi in waves
-# phi_nb = phi_nb * 4.3e-6  # phi_nb in m
-
 m = 1.0
 mm = 1.0e-3 * m
 um = 1.0e-6 * m
@@ -96,42 +89,16 @@ class NrmModel:
         # get these from mask_definitions instead
         if mask is None:
             log.info("No mask name specified for model, using jwst_g7s6c")
-            mask = mask_definitions.NRM_mask_definitions(maskname="jwst_g7s6c", 
-                                    chooseholes=chooseholes, 
+            mask = mask_definitions.NRM_mask_definitions(maskname="jwst_g7s6c",
+                                    chooseholes=chooseholes,
                                     holeshape="hex")
         elif isinstance(mask, str):
-            mask = mask_definitions.NRM_mask_definitions(maskname=mask, 
-                                    chooseholes=chooseholes, 
+            mask = mask_definitions.NRM_mask_definitions(maskname=mask,
+                                    chooseholes=chooseholes,
                                     holeshape="hex")
         self.ctrs = mask.ctrs
         self.d = mask.hdia
         self.D = mask.activeD
-
-        # if mask.lower() == 'jwst':
-        #     """
-        #     Preserve ctrs.as_designed (treat as immutable)
-        #     Reverse V2 axis coordinates to close C5 open C2, and others
-        #         follow suit...
-        #     Preserve ctrs.as_built  (treat as immutable)
-        #     """
-        #     self.ctrs_asbuilt = self.ctrs_asdesigned.copy()
-
-        #     # create 'live' hole centers in an ideal, orthogonal undistorted
-        #     #    xy pupil space,
-        #     # eg maps open hole C5 in as_designed to C2 as_built, eg C4
-        #     #    unaffected....
-        #     self.ctrs_asbuilt[:, 0] *= -1
-
-        #     # LG++ rotate hole centers by 90 deg to match MAST o/p DMS PSF with
-        #     # no affine2d transformations 8/2018 AS
-        #     # LG++ The above aligns the hole pattern with the hex analytic FT,
-        #     # flat top & bottom as seen in DMS data. 8/2018 AS
-        #     # overwrites attributes:
-        #     self.ctrs_asbuilt = utils.rotate2dccw(self.ctrs_asbuilt, np.pi / 2.0)
-
-        #     # create 'live' hole centers in an ideal, orthogonal undistorted xy
-        #     #    pupil space,
-        #     self.ctrs = self.ctrs_asbuilt.copy()
 
         self.N = len(self.ctrs)
         self.datapath = datapath
@@ -361,7 +328,7 @@ class NrmModel:
             bad pixel mask of same dimensions as image
 
         weighted: boolean
-            weight 
+            weight
 
         Returns
         -------

--- a/jwst/ami/lg_model.py
+++ b/jwst/ami/lg_model.py
@@ -21,7 +21,7 @@ mas = 1.0e-3 / (60 * 60 * 180 / np.pi)  # in radians
 
 
 class NrmModel:
-    '''
+    """
     A class for conveniently dealing with an "NRM object" This should be able
     to take an NRM_mask_definitions object for mask geometry.
     Defines mask geometry and detector-scale parameters.
@@ -31,11 +31,22 @@ class NrmModel:
     Masks: gpi_g10s40, jwst, visir
     Algorithm documented in Greenbaum, A. Z., Pueyo, L. P., Sivaramakrishnan,
     A., and Lacour, S., Astrophysical Journal vol. 798, Jan 2015.
-    '''
+    """
 
-    def __init__(self, mask=None, holeshape="circ", pixscale=None,
-                 over=1, pixweight=None, datapath="", phi=None,
-                 refdir="", chooseholes=False, affine2d=None, **kwargs):
+    def __init__(
+        self,
+        mask=None,
+        holeshape="circ",
+        pixscale=None,
+        over=1,
+        pixweight=None,
+        datapath="",
+        phi=None,
+        refdir="",
+        chooseholes=False,
+        affine2d=None,
+        **kwargs,
+    ):
         """
         Short Summary
         -------------
@@ -89,13 +100,13 @@ class NrmModel:
         # get these from mask_definitions instead
         if mask is None:
             log.info("No mask name specified for model, using jwst_g7s6c")
-            mask = mask_definitions.NRM_mask_definitions(maskname="jwst_g7s6c",
-                                    chooseholes=chooseholes,
-                                    holeshape="hex")
+            mask = mask_definitions.NRM_mask_definitions(
+                maskname="jwst_g7s6c", chooseholes=chooseholes, holeshape="hex"
+            )
         elif isinstance(mask, str):
-            mask = mask_definitions.NRM_mask_definitions(maskname=mask,
-                                    chooseholes=chooseholes,
-                                    holeshape="hex")
+            mask = mask_definitions.NRM_mask_definitions(
+                maskname=mask, chooseholes=chooseholes, holeshape="hex"
+            )
         self.ctrs = mask.ctrs
         self.d = mask.hdia
         self.D = mask.activeD
@@ -124,14 +135,14 @@ class NrmModel:
         # We apply this when sampling the PSF, not to the pupil geometry.
 
         if affine2d is None:
-            self.affine2d = utils.Affine2d(mx=1.0, my=1.0,
-                                           sx=0.0, sy=0.0,
-                                           xo=0.0, yo=0.0, name="Ideal")
+            self.affine2d = utils.Affine2d(
+                mx=1.0, my=1.0, sx=0.0, sy=0.0, xo=0.0, yo=0.0, name="Ideal"
+            )
         else:
             self.affine2d = affine2d
 
     def simulate(self, fov=None, bandpass=None, over=None, psf_offset=(0, 0)):
-        '''
+        """
         Short Summary
         -------------
         Simulate a detector-scale psf using parameters input from the call and
@@ -157,7 +168,7 @@ class NrmModel:
         -------
         Object's 'psf': float 2D array
             simulated psf
-        '''
+        """
         # why are we making this FITS object?
         self.simhdr = fits.PrimaryHDU().header
         # First set up conditions for choosing various parameters
@@ -166,24 +177,26 @@ class NrmModel:
         if over is None:
             over = 1  # ?  Always comes in as integer.
 
-        self.simhdr['OVER'] = (over, 'sim pix = det pix/over')
-        self.simhdr['PIX_OV'] = (self.pixel / float(over),
-                                 'Sim pixel scale in radians')
+        self.simhdr["OVER"] = (over, "sim pix = det pix/over")
+        self.simhdr["PIX_OV"] = (self.pixel / float(over), "Sim pixel scale in radians")
 
         self.psf_over = np.zeros((over * fov, over * fov))
         nspec = 0
         # accumulate polychromatic oversampled psf in the object
 
         for w, l in bandpass:  # w: wavelength's weight, l: lambda (wavelength)
-            self.psf_over += w * analyticnrm2.psf(self.pixel,  # det pixel, rad
-                                                  fov,   # in detpix number
-                                                  over,
-                                                  self.ctrs,
-                                                  self.d, l,
-                                                  self.phi,
-                                                  psf_offset,  # det pixels
-                                                  self.affine2d,
-                                                  shape=self.holeshape)
+            self.psf_over += w * analyticnrm2.psf(
+                self.pixel,  # det pixel, rad
+                fov,  # in detpix number
+                over,
+                self.ctrs,
+                self.d,
+                l,
+                self.phi,
+                psf_offset,  # det pixels
+                self.affine2d,
+                shape=self.holeshape,
+            )
             # offset signs fixed to agree w/DS9, +x shifts ctr R, +y shifts up
             self.simhdr["WAVL{0}".format(nspec)] = (l, "wavelength (m)")
             self.simhdr["WGHT{0}".format(nspec)] = (w, "weight")
@@ -194,8 +207,9 @@ class NrmModel:
 
         return self.psf
 
-    def make_model(self, fov=None, bandpass=None, over=1, psf_offset=(0, 0),
-                   pixscale=None):
+    def make_model(
+        self, fov=None, bandpass=None, over=1, psf_offset=(0, 0), pixscale=None
+    ):
         """
         Short Summary
         -------------
@@ -233,7 +247,7 @@ class NrmModel:
 
         self.over = over
 
-        if hasattr(self, 'pixscale_measured'):
+        if hasattr(self, "pixscale_measured"):
             if self.pixscale_measured is not None:
                 self.modelpix = self.pixscale_measured
 
@@ -251,41 +265,56 @@ class NrmModel:
 
         self.model = np.zeros((self.fov, self.fov, self.N * (self.N - 1) + 2))
         self.model_beam = np.zeros((self.over * self.fov, self.over * self.fov))
-        self.fringes = np.zeros((self.N * (self.N - 1) + 1, self.over * self.fov,
-                                 self.over * self.fov))
+        self.fringes = np.zeros(
+            (self.N * (self.N - 1) + 1, self.over * self.fov, self.over * self.fov)
+        )
 
         for w, l in bandpass:  # w: weight, l: lambda (wavelength)
             # model_array returns the envelope and fringe model as a list of
             #   oversampled fov x fov slices
-            pb, ff = analyticnrm2.model_array(self.modelctrs, l, self.over,
-                                              self.modelpix, self.fov, self.d,
-                                              shape=self.holeshape,
-                                              psf_offset=psf_offset,
-                                              affine2d=self.affine2d)
+            pb, ff = analyticnrm2.model_array(
+                self.modelctrs,
+                l,
+                self.over,
+                self.modelpix,
+                self.fov,
+                self.d,
+                shape=self.holeshape,
+                psf_offset=psf_offset,
+                affine2d=self.affine2d,
+            )
 
-            log.debug("Passed to model_array: psf_offset: {0}".
-                      format(psf_offset))
-            log.debug("Primary beam in the model created: {0}".
-                      format(pb))
+            log.debug("Passed to model_array: psf_offset: {0}".format(psf_offset))
+            log.debug("Primary beam in the model created: {0}".format(pb))
             self.model_beam += pb
             self.fringes += ff
 
             # this routine multiplies the envelope by each fringe "image"
             self.model_over = leastsqnrm.multiplyenv(pb, ff)
 
-            model_binned = np.zeros((self.fov, self.fov,
-                                     self.model_over.shape[2]))
+            model_binned = np.zeros((self.fov, self.fov, self.model_over.shape[2]))
             # loop over slices "sl" in the model
             for sl in range(self.model_over.shape[2]):
-                model_binned[:, :, sl] = utils.rebin(self.model_over[:, :, sl],
-                                                     (self.over, self.over))
+                model_binned[:, :, sl] = utils.rebin(
+                    self.model_over[:, :, sl], (self.over, self.over)
+                )
 
             self.model += w * model_binned
 
         return self.model
 
-    def fit_image(self, image, reference=None, pixguess=None, rotguess=0,
-                  psf_offset=(0, 0), modelin=None, savepsfs=False, dqm=None, weighted=False):
+    def fit_image(
+        self,
+        image,
+        reference=None,
+        pixguess=None,
+        rotguess=0,
+        psf_offset=(0, 0),
+        modelin=None,
+        savepsfs=False,
+        dqm=None,
+        weighted=False,
+    ):
         """
         Short Summary
         -------------
@@ -347,40 +376,43 @@ class NrmModel:
             if reference is None:
                 self.reference = image
                 if np.isnan(image.any()):
-                    raise ValueError("Must have non-NaN image to " +
-                                     "crosscorrelate for scale. Reference " +
-                                     "image should also be centered.")
+                    raise ValueError(
+                        "Must have non-NaN image to "
+                        + "crosscorrelate for scale. Reference "
+                        + "image should also be centered."
+                    )
             else:
                 self.reference = reference
 
             self.pixscale_measured = self.pixel
             self.fov = image.shape[0]
-            self.fittingmodel = self.make_model(self.fov,
-                                                bandpass=self.bandpass,
-                                                over=self.over, rotate=True,
-                                                psf_offset=self.bestcenter,
-                                                pixscale=self.pixel)
+            self.fittingmodel = self.make_model(
+                self.fov,
+                bandpass=self.bandpass,
+                over=self.over,
+                rotate=True,
+                psf_offset=self.bestcenter,
+                pixscale=self.pixel,
+            )
         else:
             self.fittingmodel = modelin
         if self.weighted is False:
-            self.soln, self.residual, self.cond, \
-                self.linfit_result = \
+            self.soln, self.residual, self.cond, self.linfit_result = (
                 leastsqnrm.matrix_operations(image, self.fittingmodel, dqm=dqm)
+            )
         else:
-            self.soln, self.residual, self.cond, self.singvals = leastsqnrm.weighted_operations(image, \
-                            self.fittingmodel, dqm=dqm)
+            self.soln, self.residual, self.cond, self.singvals = (
+                leastsqnrm.weighted_operations(image, self.fittingmodel, dqm=dqm)
+            )
 
         self.rawDC = self.soln[-1]
         self.flux = self.soln[0]
         self.soln = self.soln / self.soln[0]
 
         # fringephase now in radians
-        self.fringeamp, self.fringephase = \
-            leastsqnrm.tan2visibilities(self.soln)
-        self.fringepistons = utils.fringes2pistons(self.fringephase,
-                                                   len(self.ctrs))
-        self.redundant_cps = leastsqnrm.redundant_cps(self.fringephase,
-                                                      n=self.N)
+        self.fringeamp, self.fringephase = leastsqnrm.tan2visibilities(self.soln)
+        self.fringepistons = utils.fringes2pistons(self.fringephase, len(self.ctrs))
+        self.redundant_cps = leastsqnrm.redundant_cps(self.fringephase, n=self.N)
         self.redundant_cas = leastsqnrm.closure_amplitudes(self.fringeamp, n=self.N)
 
     def create_modelpsf(self):
@@ -408,8 +440,9 @@ class NrmModel:
 
         return None
 
-    def improve_scaling(self, img, scaleguess=None, rotstart=0.0,
-                        centering='PIXELCENTERED'):
+    def improve_scaling(
+        self, img, scaleguess=None, rotstart=0.0, centering="PIXELCENTERED"
+    ):
         """
         Short Summary
         -------------
@@ -442,7 +475,7 @@ class NrmModel:
         self.gof: float
             goodness of fit
         """
-        if not hasattr(self, 'bandpass'):
+        if not hasattr(self, "bandpass"):
             raise ValueError("This obj has no specified bandpass/wavelength")
 
         reffov = img.shape[0]
@@ -454,7 +487,7 @@ class NrmModel:
         # User can specify a reference set of phases (m) at an earlier point so
         #  that all PSFs are simulated with those phase pistons (e.g. measured
         #  from data at an earlier iteration
-        if not hasattr(self, 'refphi'):
+        if not hasattr(self, "refphi"):
             self.refphi = np.zeros(len(self.ctrs))
         else:
             pass
@@ -463,15 +496,20 @@ class NrmModel:
         for q, scal in enumerate(self.scallist):
             self.test_pixscale = self.pixel * scal
             self.pixscales[q] = self.test_pixscale
-            psf = self.simulate(bandpass=self.bandpass, fov=reffov,
-                                pixel=self.test_pixscale, centering=centering)
+            psf = self.simulate(
+                bandpass=self.bandpass,
+                fov=reffov,
+                pixel=self.test_pixscale,
+                centering=centering,
+            )
             pixscl_corrlist[q, :, :] = run_data_correlate(img, psf)
             self.pixscl_corr[q] = np.max(pixscl_corrlist[q])
             if True in np.isnan(self.pixscl_corr):
                 raise ValueError("Correlation produced NaNs, check your work!")
 
         self.pixscale_optimal, scal_maxy = utils.findmax(
-            mag=self.pixscales, vals=self.pixscl_corr)
+            mag=self.pixscales, vals=self.pixscl_corr
+        )
         self.pixscale_factor = self.pixscale_optimal / self.pixel
 
         radlist = self.rotlist_rad
@@ -480,18 +518,25 @@ class NrmModel:
 
         self.rots = radlist
         for q, rad in enumerate(radlist):
-            psf = self.simulate(bandpass=self.bandpass, fov=reffov,
-                                pixel=self.pixscale_optimal, rotate=rad,
-                                centering=centering)
+            psf = self.simulate(
+                bandpass=self.bandpass,
+                fov=reffov,
+                pixel=self.pixscale_optimal,
+                rotate=rad,
+                centering=centering,
+            )
 
             corrlist[q, :, :] = run_data_correlate(psf, img)
             self.corrs[q] = np.max(corrlist[q])
 
         self.rot_measured, maxy = utils.findmax(mag=self.rots, vals=self.corrs)
-        self.refpsf = self.simulate(bandpass=self.bandpass,
-                                    pixel=self.pixscale_factor * self.pixel,
-                                    fov=reffov, rotate=self.rot_measured,
-                                    centering=centering)
+        self.refpsf = self.simulate(
+            bandpass=self.bandpass,
+            pixel=self.pixscale_factor * self.pixel,
+            fov=reffov,
+            rotate=self.rot_measured,
+            centering=centering,
+        )
 
         try:
             self.gof = goodness_of_fit(img, self.refpsf)
@@ -558,8 +603,11 @@ def goodness_of_fit(data, bestfit, diskR=8):
     gof: float
         goodness of fit
     """
-    mask = np.ones(data.shape) + utils.makedisk(data.shape[0], 2) -\
-        utils.makedisk(data.shape[0], diskR)
+    mask = (
+        np.ones(data.shape)
+        + utils.makedisk(data.shape[0], 2)
+        - utils.makedisk(data.shape[0], diskR)
+    )
 
     difference = np.ma.masked_invalid(mask * (bestfit - data))
 
@@ -591,7 +639,7 @@ def run_data_correlate(data, model):
 
     """
     sci = data
-    log.debug('shape sci: %s', np.shape(sci))
+    log.debug("shape sci: %s", np.shape(sci))
 
     cor = utils.rcrosscorrelate(sci, model)
 

--- a/jwst/ami/nrm_core.py
+++ b/jwst/ami/nrm_core.py
@@ -59,7 +59,7 @@ class FringeFitter:
         if "npix" in kwargs:
             self.npix = kwargs["npix"]
         else:
-            self.npix = 'default'
+            self.npix = "default"
         # Default: unweighted fit
         self.weighted = False
         if "weighted" in kwargs:
@@ -101,19 +101,17 @@ class FringeFitter:
         for slc in range(self.instrument_data.nwav):
             self.nrm_list.append(self.fit_fringes_single_integration(slc))
 
-
         # Now save final output model(s) of all slices, averaged slices to AmiOiModels
         # averaged
         oifits_model = oifits.RawOifits(self)
         output_model = oifits_model.make_oifits()
 
         # multi-integration
-        oifits_model_multi = oifits.RawOifits(self,method='multi')
+        oifits_model_multi = oifits.RawOifits(self, method="multi")
         output_model_multi = oifits_model_multi.make_oifits()
 
         # Save cropped/centered data, model, residual in AmiLgFitModel
         lgfit = self.make_lgfitmodel()
-
 
         return output_model, output_model_multi, lgfit
 
@@ -134,24 +132,24 @@ class FringeFitter:
         """
         nslices = len(self.nrm_list)
         # 3d arrays of centered data, models, and residuals (data - model)
-        ctrd_arr = np.zeros((nslices,self.scidata.shape[1],self.scidata.shape[2]))
-        n_ctrd_arr = np.zeros((nslices,self.scidata.shape[1],self.scidata.shape[2]))
-        model_arr = np.zeros((nslices,self.scidata.shape[1],self.scidata.shape[2]))
-        n_model_arr = np.zeros((nslices,self.scidata.shape[1],self.scidata.shape[2]))
-        resid_arr = np.zeros((nslices,self.scidata.shape[1],self.scidata.shape[2]))
-        n_resid_arr = np.zeros((nslices,self.scidata.shape[1],self.scidata.shape[2]))
+        ctrd_arr = np.zeros((nslices, self.scidata.shape[1], self.scidata.shape[2]))
+        n_ctrd_arr = np.zeros((nslices, self.scidata.shape[1], self.scidata.shape[2]))
+        model_arr = np.zeros((nslices, self.scidata.shape[1], self.scidata.shape[2]))
+        n_model_arr = np.zeros((nslices, self.scidata.shape[1], self.scidata.shape[2]))
+        resid_arr = np.zeros((nslices, self.scidata.shape[1], self.scidata.shape[2]))
+        n_resid_arr = np.zeros((nslices, self.scidata.shape[1], self.scidata.shape[2]))
         # Model parameters
-        solns_arr = np.zeros((nslices,44))
+        solns_arr = np.zeros((nslices, 44))
 
-        for i,nrmslc in enumerate(self.nrm_list):
+        for i, nrmslc in enumerate(self.nrm_list):
             datapeak = nrmslc.reference.max()
-            ctrd_arr[i,:,:] = nrmslc.reference
-            n_ctrd_arr[i,:,:] = nrmslc.reference/datapeak
-            model_arr[i,:,:] = nrmslc.modelpsf
-            n_model_arr[i,:,:] = nrmslc.modelpsf/datapeak
-            resid_arr[i,:,:] = nrmslc.residual
-            n_resid_arr[i,:,:] = nrmslc.residual/datapeak
-            solns_arr[i,:] = nrmslc.soln
+            ctrd_arr[i, :, :] = nrmslc.reference
+            n_ctrd_arr[i, :, :] = nrmslc.reference / datapeak
+            model_arr[i, :, :] = nrmslc.modelpsf
+            n_model_arr[i, :, :] = nrmslc.modelpsf / datapeak
+            resid_arr[i, :, :] = nrmslc.residual
+            n_resid_arr[i, :, :] = nrmslc.residual / datapeak
+            solns_arr[i, :] = nrmslc.soln
 
         # Populate datamodel
         m = datamodels.AmiLgFitModel()
@@ -164,7 +162,6 @@ class FringeFitter:
         m.solns_table = solns_arr
 
         return m
-
 
     def fit_fringes_single_integration(self, slc):
         """
@@ -185,45 +182,57 @@ class FringeFitter:
 
         """
 
-        nrm = lg_model.NrmModel(mask=self.instrument_data.mask,
-                                pixscale=self.instrument_data.pscale_rad,
-                                holeshape=self.instrument_data.holeshape,
-                                affine2d=self.instrument_data.affine2d,
-                                over=self.oversample)
+        nrm = lg_model.NrmModel(
+            mask=self.instrument_data.mask,
+            pixscale=self.instrument_data.pscale_rad,
+            holeshape=self.instrument_data.holeshape,
+            affine2d=self.instrument_data.affine2d,
+            over=self.oversample,
+        )
 
         nrm.bandpass = self.instrument_data.wls[0]
 
-        if self.npix == 'default':
-            self.npix = self.scidata[slc,:, :].shape[0]
+        if self.npix == "default":
+            self.npix = self.scidata[slc, :, :].shape[0]
 
         self.ctrd = self.scidata[slc]
         self.dqslice = self.dqmask[slc]
 
-        nrm.reference = self.ctrd  # self.ctrd is the cropped image centered on the brightest pixel
+        nrm.reference = (
+            self.ctrd
+        )  # self.ctrd is the cropped image centered on the brightest pixel
 
         if self.psf_offset_ff is None:
             # returned values have offsets x-y flipped:
             # Finding centroids the Fourier way assumes no bad pixels case - Fourier domain mean slope
-            centroid = utils.find_centroid(self.ctrd, self.instrument_data.threshold)  # offsets from brightest pixel ctr
+            centroid = utils.find_centroid(
+                self.ctrd, self.instrument_data.threshold
+            )  # offsets from brightest pixel ctr
             # use flipped centroids to update centroid of image for JWST - check parity for GPI, Vizier,...
             # pixel coordinates: - note the flip of [0] and [1] to match DS9 view
             nrm.xpos = centroid[1]  # flip 0 and 1 to convert
             nrm.ypos = centroid[0]  # flip 0 and 1
             nrm.psf_offset = nrm.xpos, nrm.ypos  # renamed .bestcenter to .psf_offset
         else:
-            nrm.psf_offset = self.psf_offset_ff  # user-provided psf_offsetoffsets from array center are here.
+            nrm.psf_offset = (
+                self.psf_offset_ff
+            )  # user-provided psf_offsetoffsets from array center are here.
 
-        nrm.make_model(fov=self.ctrd.shape[0],
-                       bandpass=nrm.bandpass,
-                       over=self.oversample,
-                       psf_offset=nrm.psf_offset,
-                       pixscale=nrm.pixel)
+        nrm.make_model(
+            fov=self.ctrd.shape[0],
+            bandpass=nrm.bandpass,
+            over=self.oversample,
+            psf_offset=nrm.psf_offset,
+            pixscale=nrm.pixel,
+        )
 
-        nrm.fit_image(self.ctrd,
-                      modelin=nrm.model,
-                      psf_offset=nrm.psf_offset,
-                      dqm=self.dqslice,
-                      weighted=self.weighted)
+        nrm.fit_image(
+            self.ctrd,
+            modelin=nrm.model,
+            psf_offset=nrm.psf_offset,
+            dqm=self.dqslice,
+            weighted=self.weighted,
+        )
 
         """
         Attributes now stored in nrm object:
@@ -241,5 +250,5 @@ class FringeFitter:
         """
         nrm.create_modelpsf()
         # model now stored as nrm.modelpsf, also nrm.residual
-        self.nrm = nrm # this gets updated with each slice
-        return nrm # to fit_fringes_all, where the output model will be created from list of nrm objects
+        self.nrm = nrm  # this gets updated with each slice
+        return nrm  # to fit_fringes_all, where the output model will be created from list of nrm objects

--- a/jwst/ami/nrm_core.py
+++ b/jwst/ami/nrm_core.py
@@ -61,7 +61,7 @@ class FringeFitter:
         else:
             self.npix = 'default'
         # Default: unweighted fit
-        self.weighted = False    
+        self.weighted = False
         if "weighted" in kwargs:
             self.weighted = kwargs["weighted"]
         if self.weighted is True:
@@ -116,7 +116,7 @@ class FringeFitter:
 
 
         return output_model, output_model_multi, lgfit
-        
+
     def make_lgfitmodel(self):
         """
         Short Summary
@@ -213,13 +213,13 @@ class FringeFitter:
         else:
             nrm.psf_offset = self.psf_offset_ff  # user-provided psf_offsetoffsets from array center are here.
 
-        nrm.make_model(fov=self.ctrd.shape[0], 
+        nrm.make_model(fov=self.ctrd.shape[0],
                        bandpass=nrm.bandpass,
                        over=self.oversample,
                        psf_offset=nrm.psf_offset,
                        pixscale=nrm.pixel)
 
-        nrm.fit_image(self.ctrd, 
+        nrm.fit_image(self.ctrd,
                       modelin=nrm.model,
                       psf_offset=nrm.psf_offset,
                       dqm=self.dqslice,

--- a/jwst/ami/oifits.py
+++ b/jwst/ami/oifits.py
@@ -573,7 +573,6 @@ class RawOifits:
 
             uvlist.append((self.ctrs_eqt[triple[0]] - self.ctrs_eqt[triple[1]],
                            self.ctrs_eqt[triple[1]] - self.ctrs_eqt[triple[2]]))
-        # print(len(uvlist), "uvlist", uvlist)
 
         return tarray, np.array(uvlist)
 

--- a/jwst/ami/oifits.py
+++ b/jwst/ami/oifits.py
@@ -30,12 +30,12 @@ class RawOifits:
         Parameters
         ----------
         fringefitter: FringeFitter object
-            Object containing nrm_list attribute (list of nrm objects) 
+            Object containing nrm_list attribute (list of nrm objects)
             and other info needed for OIFITS files
         nh: integer
             default 7, number of holes in the NRM
         angunit: string
-            Unit of incoming angular quantities (radians or degrees). 
+            Unit of incoming angular quantities (radians or degrees).
             Will be converted to degrees for OIFITS. Default radians
         method: string
             Method to average observables: mean or median. Default median.
@@ -58,7 +58,7 @@ class RawOifits:
         else:
             self.degree = 1
 
-        self.ctrs_eqt = self.ff.instrument_data.ctrs_eqt    
+        self.ctrs_eqt = self.ff.instrument_data.ctrs_eqt
         self.ctrs_inst = self.ff.instrument_data.ctrs_inst
         self.pa = self.ff.instrument_data.pav3 # header pav3, not including v3i_yang??
 
@@ -73,7 +73,7 @@ class RawOifits:
         """
         Short Summary
         ------------
-        Calls the functions to prepare data for saving and 
+        Calls the functions to prepare data for saving and
         populate AmiOIModel.
 
         Parameters
@@ -135,14 +135,14 @@ class RawOifits:
 
         Returns
         -------
-        
+
         """
         info4oif = self.ff.instrument_data
         t = Time('%s-%s-%s' %
              (info4oif.year, info4oif.month, info4oif.day), format='fits')
 
         # central wavelength, equiv. width from effstims used for fringe fitting
-        wl, e_wl = info4oif.lam_c, info4oif.lam_c*info4oif.lam_w 
+        wl, e_wl = info4oif.lam_c, info4oif.lam_c*info4oif.lam_w
 
         # Index 0 and 1 reversed to get the good u-v coverage (same fft)
         ucoord = self.bls[:, 1]
@@ -350,7 +350,7 @@ class RawOifits:
         """
         Short Summary
         ------------
-        Set dtypes and initialize shapes for AmiOiModel arrays, 
+        Set dtypes and initialize shapes for AmiOiModel arrays,
         depending on if averaged or multi-integration version.
 
         Parameters
@@ -360,71 +360,70 @@ class RawOifits:
 
         Returns
         -------
-        
         """
         if self.method == 'multi':
             # update dimensions of arrays for multi-integration oifits
-            target_dtype = oimodel.target.dtype 
-            wavelength_dtype = np.dtype([('EFF_WAVE', '<f4'), 
+            target_dtype = oimodel.target.dtype
+            wavelength_dtype = np.dtype([('EFF_WAVE', '<f4'),
                                 ('EFF_BAND', '<f4')])
-            array_dtype = np.dtype([('TEL_NAME', 'S16'), 
-                                ('STA_NAME', 'S16'), 
-                                ('STA_INDEX', '<i2'), 
-                                ('DIAMETER', '<f4'), 
-                                ('STAXYZ', '<f8', (3,)), 
-                                ('FOV', '<f8'), 
-                                ('FOVTYPE', 'S6'), 
+            array_dtype = np.dtype([('TEL_NAME', 'S16'),
+                                ('STA_NAME', 'S16'),
+                                ('STA_INDEX', '<i2'),
+                                ('DIAMETER', '<f4'),
+                                ('STAXYZ', '<f8', (3,)),
+                                ('FOV', '<f8'),
+                                ('FOVTYPE', 'S6'),
                                 ('CTRS_EQT', '<f8', (2,)),
-                                ('PISTONS', '<f8', (self.nslices,)), 
+                                ('PISTONS', '<f8', (self.nslices,)),
                                 ('PIST_ERR', '<f8', (self.nslices,))])
-            vis_dtype = np.dtype([('TARGET_ID', '<i2'), 
-                                ('TIME', '<f8'), 
-                                ('MJD', '<f8'), 
-                                ('INT_TIME', '<f8'), 
-                                ('VISAMP', '<f8', (self.nslices,)), 
-                                ('VISAMPERR', '<f8', (self.nslices,)), 
-                                ('VISPHI', '<f8', (self.nslices,)), 
-                                ('VISPHIERR', '<f8', (self.nslices,)), 
-                                ('UCOORD', '<f8'), 
-                                ('VCOORD', '<f8'), 
-                                ('STA_INDEX', '<i2', (2,)), 
+            vis_dtype = np.dtype([('TARGET_ID', '<i2'),
+                                ('TIME', '<f8'),
+                                ('MJD', '<f8'),
+                                ('INT_TIME', '<f8'),
+                                ('VISAMP', '<f8', (self.nslices,)),
+                                ('VISAMPERR', '<f8', (self.nslices,)),
+                                ('VISPHI', '<f8', (self.nslices,)),
+                                ('VISPHIERR', '<f8', (self.nslices,)),
+                                ('UCOORD', '<f8'),
+                                ('VCOORD', '<f8'),
+                                ('STA_INDEX', '<i2', (2,)),
                                 ('FLAG', 'i1')])
-            vis2_dtype = np.dtype([('TARGET_ID', '<i2'), 
-                                ('TIME', '<f8'), 
-                                ('MJD', '<f8'), 
-                                ('INT_TIME', '<f8'), 
-                                ('VIS2DATA', '<f8', (self.nslices,)), 
-                                ('VIS2ERR', '<f8', (self.nslices,)), 
-                                ('UCOORD', '<f8'), 
-                                ('VCOORD', '<f8'), 
-                                ('STA_INDEX', '<i2', (2,)), 
+            vis2_dtype = np.dtype([('TARGET_ID', '<i2'),
+                                ('TIME', '<f8'),
+                                ('MJD', '<f8'),
+                                ('INT_TIME', '<f8'),
+                                ('VIS2DATA', '<f8', (self.nslices,)),
+                                ('VIS2ERR', '<f8', (self.nslices,)),
+                                ('UCOORD', '<f8'),
+                                ('VCOORD', '<f8'),
+                                ('STA_INDEX', '<i2', (2,)),
                                 ('FLAG', 'i1')])
-            t3_dtype = np.dtype([('TARGET_ID', '<i2'), 
-                                ('TIME', '<f8'), 
-                                ('MJD', '<f8'), 
-                                ('INT_TIME', '<f8'), 
-                                ('T3AMP', '<f8', (self.nslices,)), 
-                                ('T3AMPERR', '<f8', (self.nslices,)), 
-                                ('T3PHI', '<f8', (self.nslices,)), 
-                                ('T3PHIERR', '<f8', (self.nslices,)), 
-                                ('U1COORD', '<f8'), 
-                                ('V1COORD', '<f8'), 
-                                ('U2COORD', '<f8'), 
-                                ('V2COORD', '<f8'), 
-                                ('STA_INDEX', '<i2', (3,)), 
+            t3_dtype = np.dtype([('TARGET_ID', '<i2'),
+                                ('TIME', '<f8'),
+                                ('MJD', '<f8'),
+                                ('INT_TIME', '<f8'),
+                                ('T3AMP', '<f8', (self.nslices,)),
+                                ('T3AMPERR', '<f8', (self.nslices,)),
+                                ('T3PHI', '<f8', (self.nslices,)),
+                                ('T3PHIERR', '<f8', (self.nslices,)),
+                                ('U1COORD', '<f8'),
+                                ('V1COORD', '<f8'),
+                                ('U2COORD', '<f8'),
+                                ('V2COORD', '<f8'),
+                                ('STA_INDEX', '<i2', (3,)),
                                 ('FLAG', 'i1')])
         else:
-            target_dtype = oimodel.target.dtype 
+            target_dtype = oimodel.target.dtype
             wavelength_dtype = oimodel.wavelength.dtype
-            array_dtype = np.dtype([('TEL_NAME', 'S16'), 
-                                ('STA_NAME', 'S16'), 
-                                ('STA_INDEX', '<i2'), 
-                                ('DIAMETER', '<f4'), 
-                                ('STAXYZ', '<f8', (3,)), 
-                                ('FOV', '<f8'), 
-                                ('FOVTYPE', 'S6'), 
+            array_dtype = np.dtype([('TEL_NAME', 'S16'),
+                                ('STA_NAME', 'S16'),
+                                ('STA_INDEX', '<i2'),
+                                ('DIAMETER', '<f4'),
+                                ('STAXYZ', '<f8', (3,)),
+                                ('FOV', '<f8'),
+                                ('FOVTYPE', 'S6'),
                                 ('CTRS_EQT', '<f8', (2,)),
-                                ('PISTONS', '<f8'), 
+                                ('PISTONS', '<f8'),
                                 ('PIST_ERR', '<f8'),
                                 ])
             vis_dtype = oimodel.vis.dtype
@@ -449,7 +448,6 @@ class RawOifits:
 
         Returns
         -------
-        
         """
         m = datamodels.AmiOIModel()
         self.init_oimodel_arrays(m)
@@ -475,7 +473,6 @@ class RawOifits:
         m.array['CTRS_EQT'] = self.oifits_dct['OI_ARRAY']['CTRS_EQT']
         m.array['PISTONS'] = self.oifits_dct['OI_ARRAY']['PISTONS']
         m.array['PIST_ERR'] = self.oifits_dct['OI_ARRAY']['PIST_ERR']
-        
 
         # oi_target extension data
         m.target['TARGET_ID'] = self.oifits_dct['OI_TARGET']['TARGET_ID']
@@ -555,7 +552,7 @@ class RawOifits:
         Returns
         -------
         tarray: integer array
-            Triple hole indices (0-indexed), 
+            Triple hole indices (0-indexed),
         float array of two uv vectors in all triangles
         """
         nholes = self.ctrs_eqt.shape[0]
@@ -566,7 +563,6 @@ class RawOifits:
                     if i < j and j < k:
                         tlist.append((i, j, k))
         tarray = np.array(tlist).astype(int)
-        
 
         tname = []
         uvlist = []
@@ -695,21 +691,21 @@ class CalibOifits:
         ------------
         Modify the dtype of OI array to include different pistons columns
         for calibrated OIFITS files
-    
+
         Parameters
         ----------
-    
+
         Returns
         -------
         """
         nrows=7
-        modified_dtype = np.dtype([('TEL_NAME', 'S16'), 
-                                ('STA_NAME', 'S16'), 
-                                ('STA_INDEX', '<i2'), 
-                                ('DIAMETER', '<f4'), 
-                                ('STAXYZ', '<f8', (3,)), 
-                                ('FOV', '<f8'), 
-                                ('FOVTYPE', 'S6'), 
+        modified_dtype = np.dtype([('TEL_NAME', 'S16'),
+                                ('STA_NAME', 'S16'),
+                                ('STA_INDEX', '<i2'),
+                                ('DIAMETER', '<f4'),
+                                ('STAXYZ', '<f8', (3,)),
+                                ('FOV', '<f8'),
+                                ('FOVTYPE', 'S6'),
                                 ('CTRS_EQT', '<f8', (2,)),
                                 ('PISTON_T', '<f8'),
                                 ('PISTON_C', '<f8'),
@@ -722,12 +718,12 @@ class CalibOifits:
         """
         Short Summary
         ------------
-        Apply the calibration (normalization) routine to calibrate the 
+        Apply the calibration (normalization) routine to calibrate the
         target AmiOIModel by the calibrator (reference star) AmiOIModel
-    
+
         Parameters
         ----------
-    
+
         Returns
         -------
         calib_oimodel: AmiOIModel
@@ -745,9 +741,9 @@ class CalibOifits:
         vaerr_t = self.targoimodel.vis['VISAMPERR']
         vaerr_c = self.caloimodel.vis['VISAMPERR']
         cperr_out = np.sqrt(cperr_t**2. + cperr_c**2.)
-        sqverr_out = sqv_out * np.sqrt((sqverr_t/self.targoimodel.vis2['VIS2DATA'])**2. + 
+        sqverr_out = sqv_out * np.sqrt((sqverr_t/self.targoimodel.vis2['VIS2DATA'])**2. +
                                         (sqverr_c/self.caloimodel.vis2['VIS2DATA'])**2.)
-        vaerr_out = va_out * np.sqrt((vaerr_t/self.targoimodel.vis['VISAMP'])**2. + 
+        vaerr_out = va_out * np.sqrt((vaerr_t/self.targoimodel.vis['VISAMP'])**2. +
                                     (vaerr_c/self.caloimodel.vis['VISAMP'])**2.)
 
         pistons_t = self.targoimodel.array['PISTONS']
@@ -789,7 +785,3 @@ class CalibOifits:
         self.calib_oimodel.meta.oifits.calib = calname
 
         return self.calib_oimodel
-
-
-
-

--- a/jwst/ami/oifits.py
+++ b/jwst/ami/oifits.py
@@ -19,8 +19,6 @@ from stdatamodels.jwst import datamodels
 class RawOifits:
     def __init__(self, fringefitter, method="median"):
         """
-        Short Summary
-        -------------
         Class to store AMI data in the format required to write out to OIFITS files
         Based on ObservablesFromText from ImPlaneIA.
         Angular quantities of input are in radians from fringe fitting; converted to degrees for saving.
@@ -32,8 +30,6 @@ class RawOifits:
             and other info needed for OIFITS files
         method: string
             Method to average observables: mean or median. Default median.
-
-
         """
         self.fringe_fitter = fringefitter
         self.n_holes = 7
@@ -56,15 +52,7 @@ class RawOifits:
 
     def make_obsarrays(self):
         """
-        Short Summary
-        ------------
         Make arrays of observables of the correct shape for saving to datamodels
-
-        Parameters
-        ----------
-
-        Returns
-        -------
         """
         # arrays of observables, (nslices,nobservables) shape.
         self.fp = np.zeros((self.nslices, self.nbl))
@@ -270,8 +258,6 @@ class RawOifits:
 
     def init_oimodel_arrays(self, oimodel):
         """
-        Short Summary
-        ------------
         Set dtypes and initialize shapes for AmiOiModel arrays,
         depending on if averaged or multi-integration version.
 
@@ -279,9 +265,6 @@ class RawOifits:
         ----------
         oimodel: AmiOIModel object
             empty model
-
-        Returns
-        -------
         """
         if self.method == "multi":
             # update dimensions of arrays for multi-integration oifits
@@ -378,12 +361,7 @@ class RawOifits:
 
     def _maketriples_all(self):
         """
-        Short Summary
-        ------------
         Calculate all three-hole combinations, baselines
-
-        Parameters
-        ----------
 
         Returns
         -------
@@ -416,12 +394,7 @@ class RawOifits:
 
     def _makebaselines(self):
         """
-        Short Summary
-        ------------
         Calculate all hole pairs, baselines
-
-        Parameters
-        ----------
 
         Returns
         -------
@@ -499,8 +472,6 @@ class RawOifits:
 class CalibOifits:
     def __init__(self, targoimodel, caloimodel):
         """
-        Short Summary
-        -------------
         Calibrate (normalize) an AMI observation by subtracting closure phases
         of a reference star from those of a target and dividing visibility amplitudes
         of the target by those of the reference star.
@@ -509,7 +480,6 @@ class CalibOifits:
         ----------
         targoimodel: AmiOIModlel, target
         caloimodel: AmiOIModlel, reference star (calibrator)
-
         """
         self.targoimodel = targoimodel
         self.caloimodel = caloimodel
@@ -517,16 +487,8 @@ class CalibOifits:
 
     def update_dtype(self):
         """
-        Short Summary
-        ------------
         Modify the dtype of OI array to include different pistons columns
         for calibrated OIFITS files
-
-        Parameters
-        ----------
-
-        Returns
-        -------
         """
         nrows = 7
         modified_dtype = np.dtype(
@@ -548,13 +510,8 @@ class CalibOifits:
 
     def calibrate(self):
         """
-        Short Summary
-        ------------
         Apply the calibration (normalization) routine to calibrate the
         target AmiOIModel by the calibrator (reference star) AmiOIModel
-
-        Parameters
-        ----------
 
         Returns
         -------

--- a/jwst/ami/tests/test_ami_interface.py
+++ b/jwst/ami/tests/test_ami_interface.py
@@ -17,7 +17,7 @@ def example_model():
     model.meta.instrument.name = "NIRISS"
     model.meta.instrument.filter = "F277W"
     model.meta.subarray.name = "SUB80"
-    model.meta.observation.date = "2019-01-01"
+    model.meta.observation.date = "2021-12-26"
     model.meta.observation.time = "00:00:00"
     model.meta.target.proposer_name = ""
     model.meta.program.pi_name = "someone"
@@ -27,6 +27,7 @@ def example_model():
     model.meta.wcsinfo.v3yangle = 0.56126717
     model.meta.filename = "test_calints.fits"
     model.meta.instrument.pupil = "NRM"
+    model.meta.exposure.type = "NIS_AMI"
     return model
 
 

--- a/jwst/ami/tests/test_ami_interface.py
+++ b/jwst/ami/tests/test_ami_interface.py
@@ -9,11 +9,17 @@ from jwst.ami import AmiAnalyzeStep
 
 @pytest.fixture()
 def example_model():
-    model = datamodels.CubeModel((25, 19, 19))
+    model = datamodels.CubeModel((69, 80, 80))
     model.meta.instrument.name = "NIRISS"
     model.meta.instrument.filter = "F277W"
+    model.meta.subarray.name = "SUB80"
     model.meta.observation.date = "2019-01-01"
     model.meta.observation.time = "00:00:00"
+    model.meta.target.proposer_name = ""
+    model.meta.target.catalog_name = ""
+    model.meta.visit.start_time = "2022-06-05 12:15:41.5020000"
+    model.meta.pointing.pa_v3 = 171.8779402866089
+    model.meta.wcsinfo.v3yangle = 0.56126717
     return model
 
 
@@ -33,3 +39,7 @@ def test_ami_analyze_no_reffile_fail(monkeypatch, example_model):
 
     with pytest.raises(RuntimeError, match="No throughput reference file found."):
         AmiAnalyzeStep.call(example_model)
+
+
+def test_ami_analyze_step(example_model):
+    AmiAnalyzeStep.call(example_model)

--- a/jwst/ami/tests/test_ami_interface.py
+++ b/jwst/ami/tests/test_ami_interface.py
@@ -14,7 +14,7 @@ def test_ami_analyze_cube_fail():
     model.meta.instrument.filter = "F277W"
     model.meta.observation.date = "2019-01-01"
     model.meta.observation.time = "00:00:00"
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Input must be a 2D ImageModel."):
         AmiAnalyzeStep.call(model)
 
 
@@ -30,5 +30,5 @@ def test_ami_analyze_no_reffile_fail(monkeypatch):
         return "N/A"
     monkeypatch.setattr(stpipe.crds_client, 'get_reference_file', mockreturn)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="No throughput reference file found."):
         AmiAnalyzeStep.call(model)

--- a/jwst/ami/tests/test_ami_interface.py
+++ b/jwst/ami/tests/test_ami_interface.py
@@ -9,17 +9,24 @@ from jwst.ami import AmiAnalyzeStep
 
 @pytest.fixture()
 def example_model():
-    model = datamodels.CubeModel((69, 80, 80))
+    model = datamodels.CubeModel((2, 80, 80))
+    # some non-zero data is required as this step will center
+    # the image and find the centroid (both fail with all zeros)
+    model.data[:, 24, 24] = 1
+    model.data[:, 28, 28] = 1
     model.meta.instrument.name = "NIRISS"
     model.meta.instrument.filter = "F277W"
     model.meta.subarray.name = "SUB80"
     model.meta.observation.date = "2019-01-01"
     model.meta.observation.time = "00:00:00"
     model.meta.target.proposer_name = ""
+    model.meta.program.pi_name = "someone"
     model.meta.target.catalog_name = ""
     model.meta.visit.start_time = "2022-06-05 12:15:41.5020000"
     model.meta.pointing.pa_v3 = 171.8779402866089
     model.meta.wcsinfo.v3yangle = 0.56126717
+    model.meta.filename = "test_calints.fits"
+    model.meta.instrument.pupil = "NRM"
     return model
 
 
@@ -30,6 +37,7 @@ def test_ami_analyze_even_oversample_fail(example_model, oversample):
         AmiAnalyzeStep.call(example_model, oversample=oversample)
 
 
+@pytest.mark.skip("reference files are not currently used")
 def test_ami_analyze_no_reffile_fail(monkeypatch, example_model):
     """Make sure that ami_analyze fails if no throughput reffile is available"""
 

--- a/jwst/ami/tests/test_ami_interface.py
+++ b/jwst/ami/tests/test_ami_interface.py
@@ -7,28 +7,29 @@ from stdatamodels.jwst import datamodels
 from jwst.ami import AmiAnalyzeStep
 
 
-def test_ami_analyze_cube_fail():
-    """Make sure ami_analyze fails if input is CubeModel (_calints)"""
+@pytest.fixture()
+def example_model():
     model = datamodels.CubeModel((25, 19, 19))
     model.meta.instrument.name = "NIRISS"
     model.meta.instrument.filter = "F277W"
     model.meta.observation.date = "2019-01-01"
     model.meta.observation.time = "00:00:00"
-    with pytest.raises(RuntimeError, match="Input must be a 2D ImageModel."):
-        AmiAnalyzeStep.call(model)
+    return model
 
 
-def test_ami_analyze_no_reffile_fail(monkeypatch):
+@pytest.mark.parametrize("oversample", [2, 4])
+def test_ami_analyze_even_oversample_fail(example_model, oversample):
+    """Make sure ami_analyze fails if oversample is even"""
+    with pytest.raises(ValueError, match="Oversample value must be an odd integer."):
+        AmiAnalyzeStep.call(example_model, oversample=oversample)
+
+
+def test_ami_analyze_no_reffile_fail(monkeypatch, example_model):
     """Make sure that ami_analyze fails if no throughput reffile is available"""
-    model = datamodels.ImageModel((19, 19))
-    model.meta.instrument.name = "NIRISS"
-    model.meta.instrument.filter = "F277W"
-    model.meta.observation.date = "2019-01-01"
-    model.meta.observation.time = "00:00:00"
 
     def mockreturn(input_model, reftype, observatory=None, asn_exptypes=None):
         return "N/A"
     monkeypatch.setattr(stpipe.crds_client, 'get_reference_file', mockreturn)
 
     with pytest.raises(RuntimeError, match="No throughput reference file found."):
-        AmiAnalyzeStep.call(model)
+        AmiAnalyzeStep.call(example_model)

--- a/jwst/ami/tests/test_ami_utils.py
+++ b/jwst/ami/tests/test_ami_utils.py
@@ -35,7 +35,7 @@ def test_get_src_spec(spectype, teff):
     spec = utils.get_src_spec(spectype)
     assert isinstance(spec, SourceSpectrum)
     # check model expression for matching teff
-    re.match(f".*T_eff=(?P<teff>[0-9]+)", spec.meta["expr"]).group("teff") == str(teff)
+    re.match(r".*T_eff=(?P<teff>[0-9]+)", spec.meta["expr"]).group("teff") == str(teff)
 
 
 def test_get_src_spec_default():
@@ -43,4 +43,4 @@ def test_get_src_spec_default():
         spec = utils.get_src_spec("missing")
     assert isinstance(spec, SourceSpectrum)
     # check model expression for matching teff
-    re.match(f".*T_eff=(?P<teff>[0-9]+)", spec.meta["expr"]).group("teff") == "9500"
+    re.match(r".*T_eff=(?P<teff>[0-9]+)", spec.meta["expr"]).group("teff") == "9500"

--- a/jwst/ami/tests/test_ami_utils.py
+++ b/jwst/ami/tests/test_ami_utils.py
@@ -7,25 +7,6 @@ from synphot.spectrum import SourceSpectrum, SpectralElement
 import jwst.ami.utils as utils
 
 
-@pytest.mark.parametrize("filt, peak", [
-    ("F277W", 30533.8),
-    ("F380M", 37533.2),
-    ("F430M", 42512.1),
-    ("F480M", 48177.0),
-])
-def test_get_filt_spec(filt, peak):
-    spec = utils.get_filt_spec(filt)
-    assert isinstance(spec, SpectralElement)
-    wpeak = spec.wpeak()
-    assert wpeak.unit == "Angstrom"
-    np.isclose(spec.wpeak().value, peak, rtol=1)
-
-
-def test_get_filt_spec_fail():
-    with pytest.raises(ValueError, match="not a known NIRISS AMI filter"):
-        utils.get_filt_spec("unknown")
-
-
 # only testing a few of the catalog entries
 @pytest.mark.parametrize("spectype, teff", [
     ("O3V", 45000),

--- a/jwst/ami/tests/test_ami_utils.py
+++ b/jwst/ami/tests/test_ami_utils.py
@@ -44,3 +44,26 @@ def test_get_src_spec_default():
     assert isinstance(spec, SourceSpectrum)
     # check model expression for matching teff
     re.match(r".*T_eff=(?P<teff>[0-9]+)", spec.meta["expr"]).group("teff") == "9500"
+
+
+@pytest.mark.parametrize("shape, center", [
+    ((10, 10), (4.5, 4.5)),
+    ((11, 11), (5, 5)),
+])
+def test_centerpoint(shape, center):
+    assert utils.centerpoint(shape) == center
+
+
+def test_find_centroid():
+    arr = np.zeros((30, 30), dtype='f4')
+    arr[15, 15] = 1
+    thresh = 0.02
+    assert np.allclose(utils.find_centroid(arr, thresh), (0.5, 0.5))
+
+
+@pytest.mark.parametrize("mas, rad", [
+    (206264.8062471, 0.001),
+    (103132403.12355, 0.5),
+])
+def test_mas2rad(mas, rad):
+    assert np.isclose(utils.mas2rad(mas), rad)

--- a/jwst/ami/tests/test_ami_utils.py
+++ b/jwst/ami/tests/test_ami_utils.py
@@ -1,0 +1,16 @@
+from synphot.spectrum import SpectralElement
+
+import pytest
+
+import jwst.ami.utils as utils
+
+
+@pytest.mark.parametrize("filt", ["F277W", "F380M", "F430M", "F480M"])
+def test_get_filt_spec(filt):
+    spec = utils.get_filt_spec(filt)
+    assert isinstance(spec, SpectralElement)
+
+
+def test_get_filt_spec_fail():
+    with pytest.raises(ValueError, match="not a known NIRISS AMI filter"):
+        utils.get_filt_spec("unknown")

--- a/jwst/ami/tests/test_ami_utils.py
+++ b/jwst/ami/tests/test_ami_utils.py
@@ -2,7 +2,7 @@ import re
 
 import numpy as np
 import pytest
-from synphot.spectrum import SourceSpectrum, SpectralElement
+from synphot.spectrum import SourceSpectrum
 
 import jwst.ami.utils as utils
 

--- a/jwst/ami/tests/test_ami_utils.py
+++ b/jwst/ami/tests/test_ami_utils.py
@@ -1,16 +1,46 @@
-from synphot.spectrum import SpectralElement
+import re
 
+import numpy as np
 import pytest
+from synphot.spectrum import SourceSpectrum, SpectralElement
 
 import jwst.ami.utils as utils
 
 
-@pytest.mark.parametrize("filt", ["F277W", "F380M", "F430M", "F480M"])
-def test_get_filt_spec(filt):
+@pytest.mark.parametrize("filt, peak", [
+    ("F277W", 30533.8),
+    ("F380M", 37533.2),
+    ("F430M", 42512.1),
+    ("F480M", 48177.0),
+])
+def test_get_filt_spec(filt, peak):
     spec = utils.get_filt_spec(filt)
     assert isinstance(spec, SpectralElement)
+    wpeak = spec.wpeak()
+    assert wpeak.unit == "Angstrom"
+    np.isclose(spec.wpeak().value, peak, rtol=1)
 
 
 def test_get_filt_spec_fail():
     with pytest.raises(ValueError, match="not a known NIRISS AMI filter"):
         utils.get_filt_spec("unknown")
+
+
+# only testing a few of the catalog entries
+@pytest.mark.parametrize("spectype, teff", [
+    ("O3V", 45000),
+    ("M2I", 3500),
+])
+def test_get_src_spec(spectype, teff):
+    spec = utils.get_src_spec(spectype)
+    assert isinstance(spec, SourceSpectrum)
+    # check model expression for matching teff
+    re.match(f".*T_eff=(?P<teff>[0-9]+)", spec.meta["expr"]).group("teff") == str(teff)
+
+
+def test_get_src_spec_default():
+    with pytest.warns(UserWarning, match="Input spectral type missing did not match"):
+        spec = utils.get_src_spec("missing")
+    assert isinstance(spec, SourceSpectrum)
+    # check model expression for matching teff
+    re.match(f".*T_eff=(?P<teff>[0-9]+)", spec.meta["expr"]).group("teff") == "9500"

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -1194,6 +1194,7 @@ def img_median_replace(img_model, box_size):
 
     return img_model
 
+
 def get_filt_spec(throughput_model):
     """
     Short Summary
@@ -1210,13 +1211,13 @@ def get_filt_spec(throughput_model):
     -------
     band: synphot Spectrum object
     """
-    
     thruput = throughput_model.filter_table
     wl_list = np.asarray([tup[0] for tup in thruput])  # angstroms
     tr_list = np.asarray([tup[1] for tup in thruput])
     band = synphot.spectrum.SpectralElement(synphot.models.Empirical1D, points=wl_list,
                                             lookup_table=tr_list, keep_neg=False)
     return band
+
 
 def get_src_spec(sptype):
     """

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -3,6 +3,7 @@ from stdatamodels.jwst.datamodels import dqflags
 from . import matrix_dft
 
 import logging
+import warnings
 import numpy as np
 import numpy.fft as fft
 from scipy.integrate import simpson
@@ -1227,83 +1228,77 @@ def get_src_spec(sptype):
 
     Parameters
     ----------
-    sptype: string or synphot.Spectrum
-        valid source string (e.g. "A0V") or existing synphot Spectrum object
+    src: string
+        valid source string (e.g. "A0V")
         Defaults to A0V spectral type if input string not recognized.
 
     Returns
     -------
     synphot Spectrum object
     """
-    # check if it's already a synphot spectrum
-    if isinstance(sptype, synphot.spectrum.SourceSpectrum):
-        log.info('Input is a synphot spectrum')
-        return sptype
-    else:
-        # phoenix model lookup table used in JWST ETCs
-        lookuptable = {
-            "O3V": (45000, 0.0, 4.0),
-            "O5V": (41000, 0.0, 4.5),
-            "O7V": (37000, 0.0, 4.0),
-            "O9V": (33000, 0.0, 4.0),
-            "B0V": (30000, 0.0, 4.0),
-            "B1V": (25000, 0.0, 4.0),
-            "B3V": (19000, 0.0, 4.0),
-            "B5V": (15000, 0.0, 4.0),
-            "B8V": (12000, 0.0, 4.0),
-            "A0V": (9500, 0.0, 4.0),
-            "A1V": (9250, 0.0, 4.0),
-            "A3V": (8250, 0.0, 4.0),
-            "A5V": (8250, 0.0, 4.0),
-            "F0V": (7250, 0.0, 4.0),
-            "F2V": (7000, 0.0, 4.0),
-            "F5V": (6500, 0.0, 4.0),
-            "F8V": (6250, 0.0, 4.5),
-            "G0V": (6000, 0.0, 4.5),
-            "G2V": (5750, 0.0, 4.5),
-            "G5V": (5750, 0.0, 4.5),
-            "G8V": (5500, 0.0, 4.5),
-            "K0V": (5250, 0.0, 4.5),
-            "K2V": (4750, 0.0, 4.5),
-            "K5V": (4250, 0.0, 4.5),
-            "K7V": (4000, 0.0, 4.5),
-            "M0V": (3750, 0.0, 4.5),
-            "M2V": (3500, 0.0, 4.5),
-            "M5V": (3500, 0.0, 5.0),
-            "B0III": (29000, 0.0, 3.5),
-            "B5III": (15000, 0.0, 3.5),
-            "G0III": (5750, 0.0, 3.0),
-            "G5III": (5250, 0.0, 2.5),
-            "K0III": (4750, 0.0, 2.0),
-            "K5III": (4000, 0.0, 1.5),
-            "M0III": (3750, 0.0, 1.5),
-            "O6I": (39000, 0.0, 4.5),
-            "O8I": (34000, 0.0, 4.0),
-            "B0I": (26000, 0.0, 3.0),
-            "B5I": (14000, 0.0, 2.5),
-            "A0I": (9750, 0.0, 2.0),
-            "A5I": (8500, 0.0, 2.0),
-            "F0I": (7750, 0.0, 2.0),
-            "F5I": (7000, 0.0, 1.5),
-            "G0I": (5500, 0.0, 1.5),
-            "G5I": (4750, 0.0, 1.0),
-            "K0I": (4500, 0.0, 1.0),
-            "K5I": (3750, 0.0, 0.5),
-            "M0I": (3750, 0.0, 0.0),
-            "M2I": (3500, 0.0, 0.0)}
-        try:
-            keys = lookuptable[sptype]
-        except KeyError:
-            log.info(
-                "\n WARNING!!! \n Input spectral type %s did not match any in the catalog. Defaulting to A0V." % sptype)
-            log.info("Accepted spectral type strings are: \n %s" % lookuptable.keys())
-            keys = lookuptable["A0V"]
-        try:
-            return grid_to_spec('phoenix', keys[0], keys[1], keys[2])
-        except IOError:
-            errmsg = ("Could not find a match in catalog {catname} for key {sptype}. Check that is a valid name in the " +
-                      "lookup table, and/or that synphot is installed properly.".format())
-            raise LookupError(errmsg)
+    # phoenix model lookup table used in JWST ETCs
+    lookuptable = {
+        "O3V": (45000, 0.0, 4.0),
+        "O5V": (41000, 0.0, 4.5),
+        "O7V": (37000, 0.0, 4.0),
+        "O9V": (33000, 0.0, 4.0),
+        "B0V": (30000, 0.0, 4.0),
+        "B1V": (25000, 0.0, 4.0),
+        "B3V": (19000, 0.0, 4.0),
+        "B5V": (15000, 0.0, 4.0),
+        "B8V": (12000, 0.0, 4.0),
+        "A0V": (9500, 0.0, 4.0),
+        "A1V": (9250, 0.0, 4.0),
+        "A3V": (8250, 0.0, 4.0),
+        "A5V": (8250, 0.0, 4.0),
+        "F0V": (7250, 0.0, 4.0),
+        "F2V": (7000, 0.0, 4.0),
+        "F5V": (6500, 0.0, 4.0),
+        "F8V": (6250, 0.0, 4.5),
+        "G0V": (6000, 0.0, 4.5),
+        "G2V": (5750, 0.0, 4.5),
+        "G5V": (5750, 0.0, 4.5),
+        "G8V": (5500, 0.0, 4.5),
+        "K0V": (5250, 0.0, 4.5),
+        "K2V": (4750, 0.0, 4.5),
+        "K5V": (4250, 0.0, 4.5),
+        "K7V": (4000, 0.0, 4.5),
+        "M0V": (3750, 0.0, 4.5),
+        "M2V": (3500, 0.0, 4.5),
+        "M5V": (3500, 0.0, 5.0),
+        "B0III": (29000, 0.0, 3.5),
+        "B5III": (15000, 0.0, 3.5),
+        "G0III": (5750, 0.0, 3.0),
+        "G5III": (5250, 0.0, 2.5),
+        "K0III": (4750, 0.0, 2.0),
+        "K5III": (4000, 0.0, 1.5),
+        "M0III": (3750, 0.0, 1.5),
+        "O6I": (39000, 0.0, 4.5),
+        "O8I": (34000, 0.0, 4.0),
+        "B0I": (26000, 0.0, 3.0),
+        "B5I": (14000, 0.0, 2.5),
+        "A0I": (9750, 0.0, 2.0),
+        "A5I": (8500, 0.0, 2.0),
+        "F0I": (7750, 0.0, 2.0),
+        "F5I": (7000, 0.0, 1.5),
+        "G0I": (5500, 0.0, 1.5),
+        "G5I": (4750, 0.0, 1.0),
+        "K0I": (4500, 0.0, 1.0),
+        "K5I": (3750, 0.0, 0.5),
+        "M0I": (3750, 0.0, 0.0),
+        "M2I": (3500, 0.0, 0.0)}
+    try:
+        keys = lookuptable[sptype]
+    except KeyError:
+        warnings.warn(f"Input spectral type {sptype} did not match any in the catalog. Defaulting to A0V.")
+        keys = lookuptable["A0V"]
+    try:
+        return grid_to_spec('phoenix', keys[0], keys[1], keys[2])
+    except IOError:
+        errmsg = ("Could not find a match in catalog {catname} for key {sptype}. Check that is a valid name in the " +
+                  "lookup table, and/or that synphot is installed properly.".format())
+        raise LookupError(errmsg)
+
 
 def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19, plot=False):
     """

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -1354,7 +1354,7 @@ def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19, plot=False):
                                                width=deltawave) * bandpass
 
         binset = np.linspace(wave - deltawave, wave + deltawave,
-                             30)  
+                             30)
         binset = binset[binset >= 0]  # remove any negative values
         result = synphot.observation.Observation(srcspec, box, binset=binset).effstim('count', area=area)
         effstims.append(result)
@@ -1378,7 +1378,7 @@ def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19, plot=False):
 
 
 def get_cw_beta(bandpass):
-    """ 
+    """
     Bandpass: array where the columns are weights, wavelengths
     Return weighted mean wavelength in meters, fractional bandpass
     """
@@ -1392,7 +1392,7 @@ def get_cw_beta(bandpass):
 
 
 def _cdmatrix_to_sky(vec, cd11, cd12, cd21, cd22):
-    """ use the global header values explicitly, for clarity 
+    """ use the global header values explicitly, for clarity
         vec is 2d, units of pixels
         cdij 4 scalars, conceptually 2x2 array in units degrees/pixel
     """
@@ -1401,7 +1401,7 @@ def _cdmatrix_to_sky(vec, cd11, cd12, cd21, cd22):
 
 def degrees_per_pixel(datamodel):
     """
-    Get pixel scale info from data model 
+    Get pixel scale info from data model
     (instead of header as in ImPlaneia InstrumentData.NIRISS.degrees_per_pixel).
     If it fails to find the right keywords, use 0.0656 as/pixel
     Input: datamodel object

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -8,7 +8,6 @@ import numpy as np
 import numpy.fft as fft
 from scipy.integrate import simpson
 from astropy import units as u
-import matplotlib.pyplot as plt
 
 import synphot
 from stsynphot import grid_to_spec
@@ -1195,7 +1194,6 @@ def img_median_replace(img_model, box_size):
 
     return img_model
 
-
 def get_filt_spec(throughput_model):
     """
     Short Summary
@@ -1299,8 +1297,7 @@ def get_src_spec(sptype):
                   "lookup table, and/or that synphot is installed properly.".format())
         raise LookupError(errmsg)
 
-
-def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19, plot=False):
+def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19):
     """
     Short Summary
     ------------
@@ -1363,14 +1360,6 @@ def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19, plot=False):
     effstims /= effstims.sum()  # Normalized count rate (total=1) is unitless
     wave_m = wavesteps.to_value(u.m)  # convert to meters
     effstims = effstims.to_value()  # strip units
-
-    if plot:
-        fig, ax = plt.subplots(figsize=(7, 5))
-        ax.plot(wave_m, effstims)
-        ax.set_xlabel(r"$\lambda$ [m]")
-        ax.set_ylabel("Throughput")
-        ax.set_title("Combined Binned Spectrum (filter and source)")
-        plt.show()
 
     finalsrc = np.array((effstims,wave_m)).T # this is the order expected by InstrumentData
 

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -1391,7 +1391,7 @@ def get_cw_beta(bandpass):
     return cw, beta
 
 
-def cdmatrix_to_sky(vec, cd11, cd12, cd21, cd22):
+def _cdmatrix_to_sky(vec, cd11, cd12, cd21, cd22):
     """ use the global header values explicitly, for clarity 
         vec is 2d, units of pixels
         cdij 4 scalars, conceptually 2x2 array in units degrees/pixel
@@ -1418,8 +1418,8 @@ def degrees_per_pixel(datamodel):
         dxpix  =  np.array((1.0, 0.0)) # axis 1 step
         dypix  =  np.array((0.0, 1.0)) # axis 2 step
         # transform pixel x and y steps to RA-tan, Dec-tan degrees
-        dxsky = cdmatrix_to_sky(dxpix, cd11, cd12, cd21, cd22)
-        dysky = cdmatrix_to_sky(dypix, cd11, cd12, cd21, cd22)
+        dxsky = _cdmatrix_to_sky(dxpix, cd11, cd12, cd21, cd22)
+        dysky = _cdmatrix_to_sky(dypix, cd11, cd12, cd21, cd22)
         log.info("Used CD matrix for pixel scales")
         return np.linalg.norm(dxsky, ord=2), np.linalg.norm(dysky, ord=2)
     elif 'cdelt1' in wcsinfo and 'cdelt2' in wcsinfo:

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -17,7 +17,7 @@ log.setLevel(logging.DEBUG)
 log.addHandler(logging.NullHandler())
 
 
-class Affine2d():
+class Affine2d:
     """
     A class to help implement the Bracewell Fourier 2D affine transformation
     theorem to calculate appropriate coordinate grids in the Fourier domain (eg
@@ -89,8 +89,17 @@ class Affine2d():
     Code by Anand Sivaramakrishnan 2018
     """
 
-    def __init__(self, mx=None, my=None, sx=None, sy=None, xo=None, yo=None,
-                 rotradccw=None, name="Affine"):
+    def __init__(
+        self,
+        mx=None,
+        my=None,
+        sx=None,
+        sy=None,
+        xo=None,
+        yo=None,
+        rotradccw=None,
+        name="Affine",
+    ):
         """
         Short Summary
         -------------
@@ -154,8 +163,9 @@ class Affine2d():
         Since this uses an offset xo yo in pixels of the affine transformation,
         these are *NOT* affected by the 'oversample' in image space.  The
         vector it is dotted with is in image space."""
-        self.phase_2vector = np.array((my * xo - sx * yo,
-                                       mx * yo - sy * xo)) / self.determinant
+        self.phase_2vector = (
+            np.array((my * xo - sx * yo, mx * yo - sy * xo)) / self.determinant
+        )
 
     def forward(self, point):
         """
@@ -173,8 +183,12 @@ class Affine2d():
         trans_point: float, float
             coordinates in distorted space
         """
-        trans_point = np.array((self.mx * point[0] + self.sx * point[1] + self.xo,
-                                self.my * point[1] + self.sy * point[0] + self.yo))
+        trans_point = np.array(
+            (
+                self.mx * point[0] + self.sx * point[1] + self.xo,
+                self.my * point[1] + self.sy * point[0] + self.yo,
+            )
+        )
 
         return trans_point
 
@@ -194,11 +208,21 @@ class Affine2d():
         trans_point: float, float
             coordinates in ideal space
         """
-        trans_point = np.array(
-            (self.my * point[0] - self.sx * point[1] -
-             self.my * self.xo + self.sx * self.yo,
-             self.mx * point[1] - self.sy * point[0] -
-             self.mx * self.yo + self.sy * self.xo)) * self.determinant
+        trans_point = (
+            np.array(
+                (
+                    self.my * point[0]
+                    - self.sx * point[1]
+                    - self.my * self.xo
+                    + self.sx * self.yo,
+                    self.mx * point[1]
+                    - self.sy * point[0]
+                    - self.mx * self.yo
+                    + self.sy * self.xo,
+                )
+            )
+            * self.determinant
+        )
 
         return trans_point
 
@@ -252,8 +276,13 @@ class Affine2d():
         phase: complex array
             phase term divided by the determinant.
         """
-        phase = np.exp(2 * np.pi * 1j / self.determinant *
-                       (self.phase_2vector[0] * u + self.phase_2vector[1] * v))
+        phase = np.exp(
+            2
+            * np.pi
+            * 1j
+            / self.determinant
+            * (self.phase_2vector[0] * u + self.phase_2vector[1] * v)
+        )
 
         return phase
 
@@ -300,14 +329,14 @@ def affinepars2header(hdr, affine2d):
         fits header, updated with affine2d parameters
     """
 
-    hdr['affine'] = (affine2d.name, 'Affine2d in pupil: name')
-    hdr['aff_mx'] = (affine2d.mx, 'Affine2d in pupil: xmag')
-    hdr['aff_my'] = (affine2d.my, 'Affine2d in pupil: ymag')
-    hdr['aff_sx'] = (affine2d.sx, 'Affine2d in pupil: xshear')
-    hdr['aff_sy'] = (affine2d.sx, 'Affine2d in pupil: yshear')
-    hdr['aff_xo'] = (affine2d.xo, 'Affine2d in pupil: x offset')
-    hdr['aff_yo'] = (affine2d.yo, 'Affine2d in pupil: y offset')
-    hdr['aff_dev'] = ('analyticnrm2', 'dev_phasor')
+    hdr["affine"] = (affine2d.name, "Affine2d in pupil: name")
+    hdr["aff_mx"] = (affine2d.mx, "Affine2d in pupil: xmag")
+    hdr["aff_my"] = (affine2d.my, "Affine2d in pupil: ymag")
+    hdr["aff_sx"] = (affine2d.sx, "Affine2d in pupil: xshear")
+    hdr["aff_sy"] = (affine2d.sx, "Affine2d in pupil: yshear")
+    hdr["aff_xo"] = (affine2d.xo, "Affine2d in pupil: x offset")
+    hdr["aff_yo"] = (affine2d.yo, "Affine2d in pupil: y offset")
+    hdr["aff_dev"] = ("analyticnrm2", "dev_phasor")
 
     return hdr
 
@@ -377,8 +406,9 @@ def trim(m, s):
         # Go through all indices in the mask:
         # the x & y lists test for any index being an edge index - if none are
         # on the edge, remember the indices in new list
-        if (m[0][ii] == 0 or m[1][ii] == 0 or m[0][ii] == s - 1 or
-                m[1][ii] == s - 1) is False:
+        if (
+            m[0][ii] == 0 or m[1][ii] == 0 or m[0][ii] == s - 1 or m[1][ii] == s - 1
+        ) is False:
             xl.append(m[0][ii])
             yl.append(m[1][ii])
     m_masked = (np.asarray(xl), np.asarray(yl))
@@ -413,7 +443,7 @@ def avoidhexsingularity(rotation):
     return rotation_adjusted
 
 
-def center_imagepeak(img, r='default', cntrimg=True):
+def center_imagepeak(img, r="default", cntrimg=True):
     """
     Short Summary
     -------------
@@ -436,13 +466,15 @@ def center_imagepeak(img, r='default', cntrimg=True):
         Cropped to place the brightest pixel at the center of the img array
     """
     peakx, peaky, h = min_distance_to_edge(img, cntrimg=cntrimg)
-    log.debug(' peakx=%g, peaky=%g, distance to edge=%g', peakx, peaky, h)
-    if r == 'default':
+    log.debug(" peakx=%g, peaky=%g, distance to edge=%g", peakx, peaky, h)
+    if r == "default":
         r = h.copy()
     else:
         pass
 
-    cropped = img[int(peakx - r):int(peakx + r + 1), int(peaky - r):int(peaky + r + 1)]
+    cropped = img[
+        int(peakx - r):int(peakx + r + 1), int(peaky - r):int(peaky + r + 1)
+    ]
 
     return cropped
 
@@ -678,10 +710,14 @@ def findslope(a, m):
     tilt = (a_r - a_l) / 2.0, (a_up - a_dn) / 2.0  # raw estimate of phase slope
     c = centerpoint(a.shape)
     C = (int(c[0]), int(c[1]))
-    sigh, sigv = tilt[0][C[0] - 1:C[0] + 1, C[1] - 1:C[1] + 1].std(), \
-        tilt[1][C[0] - 1:C[0] + 1, C[1] - 1:C[1] + 1].std()
-    avgh, avgv = tilt[0][C[0] - 1:C[0] + 1, C[1] - 1:C[1] + 1].mean(), \
-        tilt[1][C[0] - 1:C[0] + 1, C[1] - 1:C[1] + 1].mean()
+    sigh, sigv = (
+        tilt[0][C[0] - 1:C[0] + 1, C[1] - 1:C[1] + 1].std(),
+        tilt[1][C[0] - 1:C[0] + 1, C[1] - 1:C[1] + 1].std(),
+    )
+    avgh, avgv = (
+        tilt[0][C[0] - 1:C[0] + 1, C[1] - 1:C[1] + 1].mean(),
+        tilt[1][C[0] - 1:C[0] + 1, C[1] - 1:C[1] + 1].mean(),
+    )
 
     # second stage mask cleaning: 5 sig rejection of mask
     newmaskh = np.where(np.abs(tilt[0] - avgh) < 5 * sigh)
@@ -773,8 +809,8 @@ def makeA(nh):
     matrixA: 2D float array
          nh columns, nh(nh-1)/2 rows (eg 21 for nh=7)
     """
-    log.debug('-------')
-    log.debug(' makeA:')
+    log.debug("-------")
+    log.debug(" makeA:")
 
     ncols = (nh * (nh - 1)) // 2
     nrows = nh
@@ -786,14 +822,14 @@ def makeA(nh):
             if h1 >= nh:
                 break
             else:
-                log.debug(' row: %s, h1: %s, h2: %s', row, h1, h2)
+                log.debug(" row: %s, h1: %s, h2: %s", row, h1, h2)
 
                 matrixA[row, h2] = -1
                 matrixA[row, h1] = +1
                 row += 1
 
-    log.debug('matrixA:')
-    log.debug(' %s', matrixA)
+    log.debug("matrixA:")
+    log.debug(" %s", matrixA)
 
     return matrixA
 
@@ -928,8 +964,9 @@ def lambdasteps(lam, frac_width, steps=4):
     steps = steps / 2.0
 
     # add some very small number to the end to include the last number.
-    lambda_array = np.arange(-1 * frac * lam + lam, frac * lam + lam + 10e-10,
-                             frac * lam / steps)
+    lambda_array = np.arange(
+        -1 * frac * lam + lam, frac * lam + lam + 10e-10, frac * lam / steps
+    )
 
     return lambda_array
 
@@ -984,7 +1021,7 @@ def crosscorrelate(a=None, b=None):
         complex array that is the correlation of the two input arrays.
     """
     if a.shape != b.shape:
-        log.critical('crosscorrelate: need identical arrays')
+        log.critical("crosscorrelate: need identical arrays")
         return None
 
     fac = np.sqrt(a.shape[0] * a.shape[1])
@@ -993,19 +1030,19 @@ def crosscorrelate(a=None, b=None):
     B = fft.fft2(b) / fac
     c = fft.ifft2(A * B.conj()) * fac * fac
 
-    log.debug('----------------')
-    log.debug(' crosscorrelate:')
-    log.debug(' a: %s:', a)
-    log.debug(' A: %s:', A)
-    log.debug(' b: %s:', b)
-    log.debug(' B: %s:', B)
-    log.debug(' c: %s:', c)
-    log.debug(' a.sum: %s:', a.sum())
-    log.debug(' b.sum: %s:', b.sum())
-    log.debug(' c.sum: %s:', c.sum())
-    log.debug(' a.sum*b.sum: %s:', a.sum() * b.sum())
-    log.debug(' c.sum.real: %s:', c.sum().real)
-    log.debug(' a.sum*b.sum/c.sum.real: %s:', a.sum() * b.sum() / c.sum().real)
+    log.debug("----------------")
+    log.debug(" crosscorrelate:")
+    log.debug(" a: %s:", a)
+    log.debug(" A: %s:", A)
+    log.debug(" b: %s:", b)
+    log.debug(" B: %s:", B)
+    log.debug(" c: %s:", c)
+    log.debug(" a.sum: %s:", a.sum())
+    log.debug(" b.sum: %s:", b.sum())
+    log.debug(" c.sum: %s:", c.sum())
+    log.debug(" a.sum*b.sum: %s:", a.sum() * b.sum())
+    log.debug(" c.sum.real: %s:", c.sum().real)
+    log.debug(" a.sum*b.sum/c.sum.real: %s:", a.sum() * b.sum() / c.sum().real)
 
     return fft.fftshift(c)
 
@@ -1034,8 +1071,9 @@ def rotate2dccw(vectors, thetarad):
     c, s = (np.cos(thetarad), np.sin(thetarad))
     ctrs_rotated = []
     for vector in vectors:
-        ctrs_rotated.append([c * vector[0] - s * vector[1],
-                             s * vector[0] + c * vector[1]])
+        ctrs_rotated.append(
+            [c * vector[0] - s * vector[1], s * vector[0] + c * vector[1]]
+        )
     rot_vectors = np.array(ctrs_rotated)
 
     return rot_vectors
@@ -1068,7 +1106,7 @@ def findmax(mag, vals, mid=1.0):
         value of vals corresponding to maxx
     """
     p = np.polyfit(mag, vals, 2)
-    fitr = np.arange(0.95 * mid, 1.05 * mid, .01)
+    fitr = np.arange(0.95 * mid, 1.05 * mid, 0.01)
     maxx, maxy, fitc = quadratic(p, fitr)
 
     return maxx, maxy
@@ -1106,16 +1144,15 @@ def pix_median_fill_value(input_array, input_dq_array, bsize, xc, yc):
 
     # Extract the region of interest for the data
     try:
-        data_array = input_array[yc - hbox:yc + hbox + 1, xc - hbox: xc + hbox + 1]
-        dq_array = input_dq_array[yc - hbox:yc + hbox + 1, xc - hbox: xc + hbox + 1]
+        data_array = input_array[yc - hbox:yc + hbox + 1, xc - hbox:xc + hbox + 1]
+        dq_array = input_dq_array[yc - hbox:yc + hbox + 1, xc - hbox:xc + hbox + 1]
     except IndexError:
         # If the box is outside the data, return 0
-        log.warning('Box for median filter is outside the data')
-        return 0.
+        log.warning("Box for median filter is outside the data")
+        return 0.0
 
     # only keep pixels not flagged with DO_NOT_USE
-    wh_good = np.where((np.bitwise_and(dq_array, dqflags.pixel['DO_NOT_USE'])
-                        == 0))
+    wh_good = np.where((np.bitwise_and(dq_array, dqflags.pixel["DO_NOT_USE"]) == 0))
     filtered_array = data_array[wh_good]
 
     # compute the median, excluding NaN's
@@ -1123,8 +1160,8 @@ def pix_median_fill_value(input_array, input_dq_array, bsize, xc, yc):
 
     # check for bad result
     if np.isnan(median_value):
-        log.warning('Median filter returned NaN; setting value to 0.')
-        median_value = 0.
+        log.warning("Median filter returned NaN; setting value to 0.")
+        median_value = 0.0
 
     return median_value
 
@@ -1145,7 +1182,7 @@ def mas2rad(mas):
     rad: float
         angle in radians
     """
-    rad = mas * (10**(-3)) / (3600 * 180 / np.pi)
+    rad = mas * (10 ** (-3)) / (3600 * 180 / np.pi)
     return rad
 
 
@@ -1172,22 +1209,25 @@ def img_median_replace(img_model, box_size):
     input_dq = img_model.dq
 
     num_nan = np.count_nonzero(np.isnan(input_data))
-    num_dq_bad = np.count_nonzero(input_dq == dqflags.pixel['DO_NOT_USE'])
+    num_dq_bad = np.count_nonzero(input_dq == dqflags.pixel["DO_NOT_USE"])
 
     # check to see if any of the pixels are bad
-    if (num_nan + num_dq_bad > 0):
+    if num_nan + num_dq_bad > 0:
 
-        log.info(f'Applying median filter for {num_nan} NaN and {num_dq_bad} DO_NOT_USE pixels')
-        bad_locations = np.where(np.isnan(input_data) |
-                                 np.equal(input_dq,
-                                          dqflags.pixel['DO_NOT_USE']))
+        log.info(
+            f"Applying median filter for {num_nan} NaN and {num_dq_bad} DO_NOT_USE pixels"
+        )
+        bad_locations = np.where(
+            np.isnan(input_data) | np.equal(input_dq, dqflags.pixel["DO_NOT_USE"])
+        )
 
         # fill the bad pixel values with the median of the data in a box region
         for i_pos in range(len(bad_locations[0])):
             y_box_pos = bad_locations[0][i_pos]
             x_box_pos = bad_locations[1][i_pos]
-            median_fill = pix_median_fill_value(input_data, input_dq,
-                                                box_size, x_box_pos, y_box_pos)
+            median_fill = pix_median_fill_value(
+                input_data, input_dq, box_size, x_box_pos, y_box_pos
+            )
             input_data[y_box_pos, x_box_pos] = median_fill
 
         img_model.data = input_data
@@ -1213,8 +1253,9 @@ def get_filt_spec(throughput_model):
     thruput = throughput_model.filter_table
     wl_list = np.asarray([tup[0] for tup in thruput])  # angstroms
     tr_list = np.asarray([tup[1] for tup in thruput])
-    band = synphot.spectrum.SpectralElement(synphot.models.Empirical1D, points=wl_list,
-                                            lookup_table=tr_list, keep_neg=False)
+    band = synphot.spectrum.SpectralElement(
+        synphot.models.Empirical1D, points=wl_list, lookup_table=tr_list, keep_neg=False
+    )
     return band
 
 
@@ -1284,18 +1325,24 @@ def get_src_spec(sptype):
         "K0I": (4500, 0.0, 1.0),
         "K5I": (3750, 0.0, 0.5),
         "M0I": (3750, 0.0, 0.0),
-        "M2I": (3500, 0.0, 0.0)}
+        "M2I": (3500, 0.0, 0.0),
+    }
     try:
         keys = lookuptable[sptype]
     except KeyError:
-        warnings.warn(f"Input spectral type {sptype} did not match any in the catalog. Defaulting to A0V.")
+        warnings.warn(
+            f"Input spectral type {sptype} did not match any in the catalog. Defaulting to A0V."
+        )
         keys = lookuptable["A0V"]
     try:
-        return grid_to_spec('phoenix', keys[0], keys[1], keys[2])
+        return grid_to_spec("phoenix", keys[0], keys[1], keys[2])
     except IOError:
-        errmsg = ("Could not find a match in catalog {catname} for key {sptype}. Check that is a valid name in the " +
-                  "lookup table, and/or that synphot is installed properly.".format())
+        errmsg = (
+            "Could not find a match in catalog {catname} for key {sptype}. Check that is a valid name in the "
+            + "lookup table, and/or that synphot is installed properly.".format()
+        )
         raise LookupError(errmsg)
+
 
 def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19):
     """
@@ -1333,7 +1380,7 @@ def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19):
         wl_filt, th_filt = wl_filt[low_idx:high_idx], th_filt[low_idx:high_idx]
     ptsin = len(wl_filt)
     if nlambda is None:
-        nlambda = ptsin # Don't bin throughput
+        nlambda = ptsin  # Don't bin throughput
     # get effstim for bins of wavelengths
     minwave, maxwave = wl_filt.min(), wl_filt.max()  # trimmed or not
     wave_bin_edges = np.linspace(minwave, maxwave, nlambda + 1)
@@ -1350,10 +1397,11 @@ def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19):
         box = synphot.spectrum.SpectralElement(synphot.models.Box1D, amplitude=1, x_0=wave,
                                                width=deltawave) * bandpass
 
-        binset = np.linspace(wave - deltawave, wave + deltawave,
-                             30)
+        binset = np.linspace(wave - deltawave, wave + deltawave, 30)
         binset = binset[binset >= 0]  # remove any negative values
-        result = synphot.observation.Observation(srcspec, box, binset=binset).effstim('count', area=area)
+        result = synphot.observation.Observation(srcspec, box, binset=binset).effstim(
+            "count", area=area
+        )
         effstims.append(result)
 
     effstims = u.Quantity(effstims)
@@ -1361,7 +1409,9 @@ def combine_src_filt(bandpass, srcspec, trim=0.01, nlambda=19):
     wave_m = wavesteps.to_value(u.m)  # convert to meters
     effstims = effstims.to_value()  # strip units
 
-    finalsrc = np.array((effstims,wave_m)).T # this is the order expected by InstrumentData
+    finalsrc = np.array(
+        (effstims, wave_m)
+    ).T  # this is the order expected by InstrumentData
 
     return finalsrc
 
@@ -1371,21 +1421,23 @@ def get_cw_beta(bandpass):
     Bandpass: array where the columns are weights, wavelengths
     Return weighted mean wavelength in meters, fractional bandpass
     """
-    wt = bandpass[:,0]
-    wl = bandpass[:,1]
-    cw = (wl*wt).sum()/wt.sum() # Weighted mean wavelength in meters "central wavelength"
+    wt = bandpass[:, 0]
+    wl = bandpass[:, 1]
+    cw = (
+        wl * wt
+    ).sum() / wt.sum()  # Weighted mean wavelength in meters "central wavelength"
     area = simpson(wt, x=wl)
-    ew = area / wt.max() # equivalent width
-    beta = ew/cw # fractional bandpass
+    ew = area / wt.max()  # equivalent width
+    beta = ew / cw  # fractional bandpass
     return cw, beta
 
 
 def _cdmatrix_to_sky(vec, cd11, cd12, cd21, cd22):
-    """ use the global header values explicitly, for clarity
-        vec is 2d, units of pixels
-        cdij 4 scalars, conceptually 2x2 array in units degrees/pixel
+    """use the global header values explicitly, for clarity
+    vec is 2d, units of pixels
+    cdij 4 scalars, conceptually 2x2 array in units degrees/pixel
     """
-    return np.array((cd11*vec[0] + cd12*vec[1], cd21*vec[0] + cd22*vec[1]))
+    return np.array((cd11 * vec[0] + cd12 * vec[1], cd21 * vec[0] + cd22 * vec[1]))
 
 
 def degrees_per_pixel(datamodel):
@@ -1397,23 +1449,29 @@ def degrees_per_pixel(datamodel):
     Returns: pixel scale in degrees/pixel
     """
     wcsinfo = datamodel.meta.wcsinfo._instance
-    if 'cd1_1' in wcsinfo and 'cd1_2' in wcsinfo and \
-        'cd2_1' in wcsinfo and 'cd2_2' in wcsinfo:
+    if (
+        "cd1_1" in wcsinfo
+        and "cd1_2" in wcsinfo
+        and "cd2_1" in wcsinfo
+        and "cd2_2" in wcsinfo
+    ):
         cd11 = datamodel.meta.wcsinfo.cd1_1
         cd12 = datamodel.meta.wcsinfo.cd1_2
         cd21 = datamodel.meta.wcsinfo.cd2_1
         cd22 = datamodel.meta.wcsinfo.cd2_2
         # Create unit vectors in detector pixel X and Y directions, units: detector pixels
-        dxpix  =  np.array((1.0, 0.0)) # axis 1 step
-        dypix  =  np.array((0.0, 1.0)) # axis 2 step
+        dxpix = np.array((1.0, 0.0))  # axis 1 step
+        dypix = np.array((0.0, 1.0))  # axis 2 step
         # transform pixel x and y steps to RA-tan, Dec-tan degrees
         dxsky = _cdmatrix_to_sky(dxpix, cd11, cd12, cd21, cd22)
         dysky = _cdmatrix_to_sky(dypix, cd11, cd12, cd21, cd22)
         log.info("Used CD matrix for pixel scales")
         return np.linalg.norm(dxsky, ord=2), np.linalg.norm(dysky, ord=2)
-    elif 'cdelt1' in wcsinfo and 'cdelt2' in wcsinfo:
+    elif "cdelt1" in wcsinfo and "cdelt2" in wcsinfo:
         return datamodel.meta.wcsinfo.cdelt1, datamodel.meta.wcsinfo.cdelt2
         log.info("Used CDELT[12] for pixel scales")
     else:
-        log.info('WARNING: NIRISS pixel scales not in header.  Using 65.6 mas in deg/pix')
-        return 65.6/(60.0*60.0*1000), 65.6/(60.0*60.0*1000)
+        log.info(
+            "WARNING: NIRISS pixel scales not in header.  Using 65.6 mas in deg/pix"
+        )
+        return 65.6 / (60.0 * 60.0 * 1000), 65.6 / (60.0 * 60.0 * 1000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "asdf>=2.15.1,<4",
     "asdf-transform-schemas>=0.3.0",
     "astropy>=5.3",
-    "astroquery>=0.4.6",
     "BayesicFitting>=3.0.1",
     "crds>=11.17.14",
     "drizzle>=1.14.3,<1.15.0",

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,7 @@ pass_env =
     PASS_INVALID_VALUES
     VALIDATE_ON_ASSIGNMENT
     TEST_BIGDATA
+    WEBBPSF_PATH
 set_env =
     sdpdeps,regtests: CRDS_CONTEXT = jwst-edit
 extras =


### PR DESCRIPTION
This PR:
- adds a few unit tests for the new AMI code. These include one that runs the step with 'fake' data which should cover much of a new code. Once this is merged we can look at the coverage report to see what branches are not covered and see if we can generate a few other 'fake' data inputs that use those paths.
- fixes the style (the code should now pass the style check)
- removes the astroquery dependency
- removes some commented out code
- simplifies `oifits.py` removing the need for the intermediate `oifits_dct`
- renames a few variables to improve readability (e.g. `t` to `observation_date` etc). Much more can be done here.
- removes the `verbose` and `plot` arguments replacing the `verbose` usage with log messages

The regression test passes with this PR (however see https://github.com/spacetelescope/jwst/pull/7862#discussion_r1488401215 for a note about oifits violations in the current truth files).

Please let me know if you have any questions/comments. Thanks!

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
