### PR TITLE
Patch 1

### DIFF
--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -36,7 +36,7 @@ logger.addHandler(logging.NullHandler())
 # have to exist. Used by `find_suffixes` to
 # add to the result it produces.
 SUFFIXES_TO_ADD = [
-    'ami', 'amiavg', 'aminorm', 'ami-oi',
+    'ami', 'amiavg', 'aminorm', 'ami-oi', 'aminorm-oi',
     'blot', 'bsub', 'bsubints',
     'c1d', 'cal', 'calints', 'cat', 'crf', 'crfints',
     'dark',
@@ -52,7 +52,15 @@ SUFFIXES_TO_ADD = [
 
 # Suffixes that are discovered but should not be considered.
 # Used by `find_suffixes` to remove undesired values it has found.
-SUFFIXES_TO_DISCARD = ['engdblogstep', 'functionwrapper', 'pipeline', 'rscd_step', 'step', 'systemcall']
+SUFFIXES_TO_DISCARD = [
+    'ami_average',
+    'engdblogstep',
+    'functionwrapper',
+    'pipeline',
+    'rscd_step',
+    'step',
+    'systemcall',
+]
 
 
 # Calculated suffixes.


### PR DESCRIPTION
Fixes suffix test failure.

Adds crds mock for ami_analyze unit tests to mock a `nrm` file to allow unit tests to run against crds (and not require crds-test).

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
